### PR TITLE
feat: switch ASR to Zipformer Chinese and fix sample rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## 功能
 
-- 🎤 **实时语音识别**：基于 Sherpa-ONNX，完全离线，中文优化
+- 🎤 **实时语音识别**：基于 Sherpa-ONNX Zipformer，完全离线，中文优化
 - 📝 **全屏字幕显示**：黑底大字，实时显示你说的每一句话
 - 🔍 **词库分析**：自动检测填充词、犹豫词、笼统词，给出精准替代
 - 🤖 **AI反馈**：支持 Groq/OpenAI/DeepSeek/Ollama 多后端
@@ -21,25 +21,24 @@ npm install
 
 ### 2. 下载语音识别模型
 
-需要下载 Sherpa-ONNX 的 streaming paraformer 中英双语模型：
+需要下载 Sherpa-ONNX 的 streaming Zipformer 中文模型：
 
 ```bash
 cd models
 
-# 方法一：使用 wget
-wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-paraformer-bilingual-zh-en.tar.bz2
-tar xvf sherpa-onnx-streaming-paraformer-bilingual-zh-en.tar.bz2
-
-# 方法二：使用 huggingface
-# https://huggingface.co/csukuangfj/sherpa-onnx-streaming-paraformer-bilingual-zh-en
+wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30.tar.bz2
+tar xvf sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30.tar.bz2
+rm sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30.tar.bz2
 ```
 
 下载后 `models/` 目录应包含：
+
 ```
 models/
-└── sherpa-onnx-streaming-paraformer-bilingual-zh-en/
+└── sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30/
     ├── encoder.int8.onnx
-    ├── decoder.int8.onnx
+    ├── decoder.onnx
+    ├── joiner.int8.onnx
     └── tokens.txt
 ```
 ### 3. 启动应用

--- a/lib/asr.js
+++ b/lib/asr.js
@@ -1,7 +1,7 @@
 /**
- * 语音识别模块 - 基于 sherpa-onnx-node
- * 使用 streaming recognizer 实现实时中文语音识别
- * 录音通过 Electron 渲染进程的 Web Audio API 采集，音频数据通过 IPC 传入
+ * Speech recognition via sherpa-onnx-node
+ * Streaming Zipformer transducer (Chinese)
+ * Audio is captured in the renderer via Web Audio and fed over IPC.
  */
 
 const path = require('path');
@@ -12,14 +12,20 @@ let stream = null;
 let isRunning = false;
 
 const MODELS_DIR = path.join(__dirname, '..', 'models');
-const MODEL_SUBDIR = 'sherpa-onnx-streaming-paraformer-bilingual-zh-en';
+const MODEL_SUBDIR = 'sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30';
+const TARGET_SAMPLE_RATE = 16000;
 
 /**
- * 检查模型文件是否存在
+ * Check that required model files exist
  */
 function checkModels() {
   const modelDir = path.join(MODELS_DIR, MODEL_SUBDIR);
-  const files = ['encoder.int8.onnx', 'decoder.int8.onnx', 'tokens.txt'];
+  const files = [
+    'encoder.int8.onnx',
+    'decoder.onnx',
+    'joiner.int8.onnx',
+    'tokens.txt'
+  ];
 
   for (const file of files) {
     const fullPath = path.join(modelDir, file);
@@ -33,11 +39,11 @@ function checkModels() {
 }
 
 /**
- * 初始化 ASR 引擎
+ * Initialize the ASR engine
  */
 async function initASR() {
   if (recognizer) {
-    // 已初始化，重置stream即可
+    // Reuse engine, reset stream for a new session
     stream = recognizer.createStream();
     isRunning = true;
     console.log('[ASR] 重用已有引擎，创建新stream');
@@ -51,13 +57,14 @@ async function initASR() {
 
   const config = {
     featConfig: {
-      sampleRate: 16000,
+      sampleRate: TARGET_SAMPLE_RATE,
       featureDim: 80
     },
     modelConfig: {
-      paraformer: {
+      transducer: {
         encoder: path.join(modelDir, 'encoder.int8.onnx'),
-        decoder: path.join(modelDir, 'decoder.int8.onnx'),
+        decoder: path.join(modelDir, 'decoder.onnx'),
+        joiner: path.join(modelDir, 'joiner.int8.onnx')
       },
       tokens: path.join(modelDir, 'tokens.txt'),
       numThreads: 2,
@@ -76,19 +83,20 @@ async function initASR() {
   stream = recognizer.createStream();
   isRunning = true;
 
-  console.log('[ASR] 识别引擎初始化完成');
+  console.log('[ASR] Zipformer 中文识别引擎初始化完成');
 }
 
 /**
- * 接收渲染进程发来的音频数据进行识别
- * @param {Float32Array} samples - 16kHz 单声道音频采样
+ * Feed audio samples from the renderer for recognition
+ * @param {Float32Array} samples
+ * @param {number} [sampleRate=16000] - actual capture rate (sherpa resamples if needed)
  * @returns {{ text: string, isFinal: boolean } | null}
  */
-function feedAudio(samples) {
+function feedAudio(samples, sampleRate = TARGET_SAMPLE_RATE) {
   if (!isRunning || !stream || !recognizer) return null;
 
-  // sherpa-onnx-node API: acceptWaveform({ samples, sampleRate })
-  stream.acceptWaveform({ samples, sampleRate: 16000 });
+  const rate = Number(sampleRate) > 0 ? Number(sampleRate) : TARGET_SAMPLE_RATE;
+  stream.acceptWaveform({ samples, sampleRate: rate });
 
   while (recognizer.isReady(stream)) {
     recognizer.decode(stream);
@@ -109,8 +117,8 @@ function feedAudio(samples) {
 }
 
 /**
- * 停止识别
- * @returns {string} 最后的未确认文本
+ * Stop recognition and return any remaining partial text
+ * @returns {string}
  */
 function stopRecognition() {
   isRunning = false;

--- a/main.js
+++ b/main.js
@@ -194,11 +194,11 @@ ipcMain.handle('init-asr', async () => {
   }
 });
 
-// 接收渲染进程发来的音频数据
-ipcMain.handle('feed-audio', (event, samplesArray) => {
+// 接收渲染进程发来的音频数据（sampleRate 为实际采集率，由 sherpa 内部重采样）
+ipcMain.handle('feed-audio', (event, samplesArray, sampleRate) => {
   if (!asrReady) return null;
   const samples = new Float32Array(samplesArray);
-  const result = feedAudio(samples);
+  const result = feedAudio(samples, sampleRate);
   return result; // { text, isFinal } or null
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "node-microphone": "^0.1.0",
         "sherpa-onnx-node": "^1.10.0"
       },
       "devDependencies": {
-        "electron": "^33.0.0"
+        "electron": "^33.4.11"
       }
     },
     "node_modules/@electron/get": {
@@ -642,15 +641,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-microphone": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/node-microphone/-/node-microphone-0.1.6.tgz",
-      "integrity": "sha512-5229wtpVYNU2gR8zpkABVSdp4wT9qagJgj6pELEIkAVbOXFmaCM35qN3z4ylu3OwFfEKqQ4h9u8Lb58DzaBieQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,20 @@
   "description": "宇宙无敌表达训练系统 - 本地桌面版",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
-    "dev": "electron . --dev"
+    "start": "node scripts/run-electron.js",
+    "dev": "node scripts/run-electron.js --dev"
   },
-  "keywords": ["expression", "training", "speech", "asr", "chinese"],
+  "keywords": [
+    "expression",
+    "training",
+    "speech",
+    "asr",
+    "chinese"
+  ],
   "author": "sisi",
   "license": "MIT",
   "devDependencies": {
-    "electron": "^33.0.0"
+    "electron": "^33.4.11"
   },
   "dependencies": {
     "sherpa-onnx-node": "^1.10.0"

--- a/preload.js
+++ b/preload.js
@@ -14,7 +14,7 @@ contextBridge.exposeInMainWorld('api', {
 
   // 语音识别 - 使用 Web Audio 方案
   initASR: () => ipcRenderer.invoke('init-asr'),
-  feedAudio: (samples) => ipcRenderer.invoke('feed-audio', Array.from(samples)),
+  feedAudio: (samples, sampleRate) => ipcRenderer.invoke('feed-audio', Array.from(samples), sampleRate),
   stopASR: () => ipcRenderer.invoke('stop-asr'),
   onASRResult: (callback) => {
     ipcRenderer.on('asr-result', (event, data) => callback(data));

--- a/scripts/run-electron.js
+++ b/scripts/run-electron.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Launch Electron without ELECTRON_RUN_AS_NODE.
+ * Cursor terminals inject that env var, which makes require('electron').app undefined.
+ */
+const { spawn } = require('child_process');
+const electron = require('electron');
+
+const env = { ...process.env };
+delete env.ELECTRON_RUN_AS_NODE;
+
+const child = spawn(electron, ['.', ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  env
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/src/app.js
+++ b/src/app.js
@@ -81,14 +81,23 @@ class ExpressionTrainer {
     }
 
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true
+        }
+      });
+      // Request 16kHz; macOS may still use device rate — pass actual rate to ASR
       this.audioContext = new AudioContext({ sampleRate: 16000 });
+      const captureRate = this.audioContext.sampleRate;
+      console.log(`[Audio] capture sampleRate=${captureRate}`);
       const source = this.audioContext.createMediaStreamSource(stream);
       this.audioProcessor = this.audioContext.createScriptProcessor(4096, 1, 1);
       this.audioProcessor.onaudioprocess = async (e) => {
         if (!this.isRecording || this.isPaused) return;
         const samples = e.inputBuffer.getChannelData(0);
-        const result = await window.api.feedAudio(samples);
+        const result = await window.api.feedAudio(samples, captureRate);
         if (result) this.handleASRResult(result);
       };
       source.connect(this.audioProcessor);


### PR DESCRIPTION
## Summary

- Replace streaming Paraformer bilingual ASR with **Zipformer Chinese int8 (2025-06-30)** to reduce character-level stuttering on Mandarin speech
- Pass the real `AudioContext` sample rate into sherpa so macOS device-rate captures (often 48kHz) are resampled correctly instead of being treated as 16kHz
- Add a small cross-platform Electron launcher that clears `ELECTRON_RUN_AS_NODE` (injected by some IDEs like Cursor)

## Test plan

- [ ] Download the new model under `models/` as documented in README
- [ ] `npm install` then `npm start`
- [ ] Speak a short Chinese sentence and confirm subtitles match speech without heavy 叠字 (e.g. 「我我」「这个这个」)
- [ ] Confirm filler-word highlighting and realtime feedback still work
- [ ] (Optional) Decode `models/.../test_wavs/0.wav` via `lib/asr.js` and expect near: 「对我做了介绍啊那么我想说的是呢大家如果对我的研究感兴趣呢」


Made with [Cursor](https://cursor.com)