### PR TITLE
修复动态内容渲染中的 innerHTML 安全风险

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "node-microphone": "^0.1.0",
         "sherpa-onnx-node": "^1.10.0"
       },
       "devDependencies": {
@@ -642,15 +641,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-microphone": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/node-microphone/-/node-microphone-0.1.6.tgz",
-      "integrity": "sha512-5229wtpVYNU2gR8zpkABVSdp4wT9qagJgj6pELEIkAVbOXFmaCM35qN3z4ylu3OwFfEKqQ4h9u8Lb58DzaBieQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",

--- a/src/app.js
+++ b/src/app.js
@@ -58,7 +58,8 @@ class ExpressionTrainer {
     document.getElementById('btn-prompt-editor').addEventListener('click', () => window.api.openPromptEditor());
     this.btnCloseReport.addEventListener('click', () => this.reportModal.classList.add('hidden'));
     this.btnCopyReport.addEventListener('click', () => {
-      const reportText = this.reportBody.innerText;
+      const reportContent = this.reportBody.querySelector('.report-content');
+      const reportText = reportContent ? reportContent.innerText : this.reportBody.innerText;
       navigator.clipboard.writeText(reportText).then(() => {
         this.btnCopyReport.textContent = '✅ 已复制';
         setTimeout(() => { this.btnCopyReport.textContent = '📋 复制全文'; }, 2000);
@@ -106,7 +107,7 @@ class ExpressionTrainer {
     this.fullText = '';
     this.sentences = [];
     this.resetStats();
-    this.subtitleContainer.innerHTML = '';
+    this.subtitleContainer.replaceChildren();
 
     // UI
     this.btnStart.classList.add('hidden');
@@ -194,7 +195,7 @@ class ExpressionTrainer {
       // 新行
       const line = document.createElement('div');
       line.className = 'subtitle-line';
-      line.innerHTML = this.highlightText(currentText);
+      line.appendChild(this.highlightText(currentText));
       this.subtitleContainer.appendChild(line);
     } else {
       let interim = this.subtitleContainer.querySelector('.interim-line');
@@ -211,16 +212,45 @@ class ExpressionTrainer {
   }
 
   highlightText(text) {
-    let result = text;
     const vagueWords = ['开心','难过','害怕','生气','不舒服','很好','很多','很快','很大','很小','好看','不好','喜欢','讨厌','觉得','想想'];
-    vagueWords.forEach(w => {
-      result = result.replace(new RegExp(w, 'g'), `<span class="vague">${w}</span>`);
-    });
-    const fillerPatterns = /(嗯|啊|呃|额|那个|就是|然后|这个|对吧|是吧|反正|基本上)/g;
-    result = result.replace(fillerPatterns, '<span class="filler">$1</span>');
-    const hedgePatterns = /(可能|也许|大概|应该|我觉得|好像|似乎|或许|不一定|差不多|感觉)/g;
-    result = result.replace(hedgePatterns, '<span class="hedge">$1</span>');
-    return result;
+    const fillerWords = ['嗯','啊','呃','额','那个','就是','然后','这个','对吧','是吧','反正','基本上'];
+    const hedgeWords = ['可能','也许','大概','应该','我觉得','好像','似乎','或许','不一定','差不多','感觉'];
+    const patterns = [
+      ...vagueWords.map(word => ({ word, className: 'vague', priority: 0 })),
+      ...fillerWords.map(word => ({ word, className: 'filler', priority: 1 })),
+      ...hedgeWords.map(word => ({ word, className: 'hedge', priority: 2 }))
+    ].sort((a, b) => b.word.length - a.word.length || a.priority - b.priority);
+
+    const fragment = document.createDocumentFragment();
+    const source = String(text ?? '');
+    let cursor = 0;
+    let plainStart = 0;
+
+    while (cursor < source.length) {
+      const matched = patterns.find(item => source.startsWith(item.word, cursor));
+      if (!matched) {
+        cursor += 1;
+        continue;
+      }
+
+      if (cursor > plainStart) {
+        fragment.appendChild(document.createTextNode(source.slice(plainStart, cursor)));
+      }
+
+      const span = document.createElement('span');
+      span.className = matched.className;
+      span.textContent = matched.word;
+      fragment.appendChild(span);
+
+      cursor += matched.word.length;
+      plainStart = cursor;
+    }
+
+    if (plainStart < source.length) {
+      fragment.appendChild(document.createTextNode(source.slice(plainStart)));
+    }
+
+    return fragment;
   }
 
   // ===== 分析 =====
@@ -307,7 +337,10 @@ class ExpressionTrainer {
   // ===== 报告 =====
 
   async generateReport() {
-    this.reportBody.innerHTML = '<p style="text-align:center;color:#666;padding:40px;">正在生成报告...</p>';
+    const loading = document.createElement('p');
+    loading.textContent = '正在生成报告...';
+    loading.style.cssText = 'text-align:center;color:#666;padding:40px;';
+    this.reportBody.replaceChildren(loading);
     this.reportModal.classList.remove('hidden');
 
     const result = await window.api.getFinalReport({
@@ -319,31 +352,152 @@ class ExpressionTrainer {
       this.lastReport = result.report;
       this.renderReport(result.report);
     } else {
-      this.reportBody.innerHTML = `<p style="color:#ff6b6b;">生成失败: ${result.error}</p>`;
+      const error = document.createElement('p');
+      error.style.color = '#ff6b6b';
+      error.textContent = `生成失败: ${result.error}`;
+      this.reportBody.replaceChildren(error);
     }
   }
 
   renderReport(report) {
-    let html = report
-      .replace(/^### (.+)$/gm, '<h3>$1</h3>')
-      .replace(/^## (.+)$/gm, '<h2>$1</h2>')
-      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-      .replace(/`([^`]+)`/g, '<code>$1</code>')
-      .replace(/^> (.+)$/gm, '<blockquote>$1</blockquote>')
-      .replace(/\|(.+)\|/g, (match) => {
-        // 简单表格支持
-        return match;
-      })
-      .replace(/\n/g, '<br>');
+    const actions = document.createElement('div');
+    actions.style.cssText = 'text-align:right;margin-bottom:12px;';
 
-    this.reportBody.innerHTML = `
-      <div style="text-align:right;margin-bottom:12px;">
-        <button id="btn-save-report" style="background:#E5007E;color:#fff;border:none;border-radius:6px;padding:8px 14px;font-size:12px;cursor:pointer;">💾 保存为 Markdown</button>
-      </div>
-      ${html}
-    `;
+    const saveButton = document.createElement('button');
+    saveButton.id = 'btn-save-report';
+    saveButton.type = 'button';
+    saveButton.textContent = '💾 保存为 Markdown';
+    saveButton.style.cssText = 'background:#E5007E;color:#fff;border:none;border-radius:6px;padding:8px 14px;font-size:12px;cursor:pointer;';
+    saveButton.addEventListener('click', () => this.saveReport());
+    actions.appendChild(saveButton);
 
-    document.getElementById('btn-save-report').addEventListener('click', () => this.saveReport());
+    const content = document.createElement('div');
+    content.className = 'report-content';
+    content.appendChild(this.renderMarkdown(report));
+
+    this.reportBody.replaceChildren(actions, content);
+  }
+
+  renderMarkdown(markdown) {
+    const fragment = document.createDocumentFragment();
+    const lines = String(markdown ?? '').replace(/\r\n?/g, '\n').split('\n');
+    const isTableRow = line => /^\s*\|.*\|\s*$/.test(line);
+    const getTableCells = line => line.trim().replace(/^\||\|$/g, '').split('|').map(cell => cell.trim());
+    const isTableSeparator = line => {
+      if (!isTableRow(line)) return false;
+      const cells = getTableCells(line);
+      return cells.length > 0 && cells.every(cell => /^:?-{3,}:?$/.test(cell));
+    };
+    let index = 0;
+
+    while (index < lines.length) {
+      const line = lines[index];
+
+      if (!line.trim()) {
+        fragment.appendChild(document.createElement('br'));
+        index += 1;
+        continue;
+      }
+
+      const heading = line.match(/^(#{1,3})\s+(.+)$/);
+      if (heading) {
+        const element = document.createElement(`h${heading[1].length}`);
+        this.appendInlineMarkdown(element, heading[2]);
+        fragment.appendChild(element);
+        index += 1;
+        continue;
+      }
+
+      if (/^\s*---+\s*$/.test(line)) {
+        fragment.appendChild(document.createElement('hr'));
+        index += 1;
+        continue;
+      }
+
+      if (isTableRow(line) && isTableSeparator(lines[index + 1] || '')) {
+        const table = document.createElement('table');
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+        getTableCells(line).forEach(cellText => {
+          const cell = document.createElement('th');
+          this.appendInlineMarkdown(cell, cellText);
+          headerRow.appendChild(cell);
+        });
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
+        const tbody = document.createElement('tbody');
+        index += 2;
+        while (index < lines.length && isTableRow(lines[index]) && !isTableSeparator(lines[index])) {
+          const row = document.createElement('tr');
+          getTableCells(lines[index]).forEach(cellText => {
+            const cell = document.createElement('td');
+            this.appendInlineMarkdown(cell, cellText);
+            row.appendChild(cell);
+          });
+          tbody.appendChild(row);
+          index += 1;
+        }
+        table.appendChild(tbody);
+        fragment.appendChild(table);
+        continue;
+      }
+
+      if (/^>/.test(line)) {
+        const quote = document.createElement('blockquote');
+        let firstLine = true;
+        while (index < lines.length && /^>/.test(lines[index])) {
+          if (!firstLine) quote.appendChild(document.createElement('br'));
+          this.appendInlineMarkdown(quote, lines[index].replace(/^>\s?/, ''));
+          firstLine = false;
+          index += 1;
+        }
+        fragment.appendChild(quote);
+        continue;
+      }
+
+      if (/^\s*[-*]\s+/.test(line)) {
+        const list = document.createElement('ul');
+        while (index < lines.length && /^\s*[-*]\s+/.test(lines[index])) {
+          const item = document.createElement('li');
+          this.appendInlineMarkdown(item, lines[index].replace(/^\s*[-*]\s+/, ''));
+          list.appendChild(item);
+          index += 1;
+        }
+        fragment.appendChild(list);
+        continue;
+      }
+
+      const paragraph = document.createElement('p');
+      this.appendInlineMarkdown(paragraph, line);
+      fragment.appendChild(paragraph);
+      index += 1;
+    }
+
+    return fragment;
+  }
+
+  appendInlineMarkdown(container, text) {
+    const source = String(text ?? '');
+    const tokenPattern = /(\*\*[^*\n]+?\*\*|`[^`\n]+?`)/g;
+    let lastIndex = 0;
+    let match;
+
+    while ((match = tokenPattern.exec(source)) !== null) {
+      if (match.index > lastIndex) {
+        container.appendChild(document.createTextNode(source.slice(lastIndex, match.index)));
+      }
+
+      const isStrong = match[0].startsWith('**');
+      const element = document.createElement(isStrong ? 'strong' : 'code');
+      element.textContent = isStrong ? match[0].slice(2, -2) : match[0].slice(1, -1);
+      container.appendChild(element);
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < source.length) {
+      container.appendChild(document.createTextNode(source.slice(lastIndex)));
+    }
   }
 
   async saveReport() {
@@ -381,7 +535,7 @@ class ExpressionTrainer {
   resetStats() {
     this.stats = { fillers: 0, hedges: 0, vagueWords: 0, totalWords: 0, duration: 0 };
     this.updateStatsDisplay();
-    this.feedbackContent.innerHTML = '';
+    this.feedbackContent.replaceChildren();
   }
 
   showError(msg) {
@@ -425,8 +579,11 @@ class ExpressionTrainer {
     this.fullText = '';
     this.sentences = [];
     this.lastReport = '';
-    this.subtitleContainer.innerHTML = '<div class="subtitle-line hint">点击下方按钮开始说话</div>';
-    this.feedbackContent.innerHTML = '';
+    const hint = document.createElement('div');
+    hint.className = 'subtitle-line hint';
+    hint.textContent = '点击下方按钮开始说话';
+    this.subtitleContainer.replaceChildren(hint);
+    this.feedbackContent.replaceChildren();
     this.resetStats();
     this.timer.textContent = '00:00';
     this.timer.classList.remove('active');
@@ -452,7 +609,7 @@ class ExpressionTrainer {
     this.pasteModal.classList.add('hidden');
 
     // 把文本显示到字幕区（高亮标记）
-    this.subtitleContainer.innerHTML = '';
+    this.subtitleContainer.replaceChildren();
     this.fullText = text;
     this.resetStats();
 
@@ -463,7 +620,7 @@ class ExpressionTrainer {
     for (const sentence of sentences) {
       const line = document.createElement('div');
       line.className = 'subtitle-line';
-      line.innerHTML = this.highlightText(sentence.trim());
+      line.appendChild(this.highlightText(sentence.trim()));
       this.subtitleContainer.appendChild(line);
 
       // 词库分析

--- a/src/lexicon-playground.html
+++ b/src/lexicon-playground.html
@@ -344,123 +344,126 @@ for (const [cat, words] of Object.entries(TIERED_LEXICON)) {
 const input = document.getElementById('input');
 const output = document.getElementById('output');
 const cardsDiv = document.getElementById('cards');
+const HIGHLIGHT_PATTERNS = [
+  ...Object.keys(tier1Map).map(word => ({ word, className: 'highlight', type: 'vague', priority: 0 })),
+  ...FILLER_WORDS.map(word => ({ word, className: 'highlight-filler', type: 'filler', priority: 1 })),
+  ...HEDGE_WORDS.map(word => ({ word, className: 'highlight-hedge', type: 'hedge', priority: 2 }))
+].sort((a, b) => b.word.length - a.word.length || a.priority - b.priority);
+
+function createTextElement(tagName, className, text) {
+  const element = document.createElement(tagName);
+  if (className) element.className = className;
+  element.textContent = text;
+  return element;
+}
+
+function appendTextWithBreaks(container, text) {
+  const parts = String(text).split('\n');
+  parts.forEach((part, index) => {
+    if (part) container.appendChild(document.createTextNode(part));
+    if (index < parts.length - 1) container.appendChild(document.createElement('br'));
+  });
+}
 
 input.addEventListener('input', () => {
   const text = input.value;
   if (!text.trim()) {
-    output.innerHTML = '<span style="color:#ccc">输入内容后这里会实时显示高亮...</span>';
+    const placeholder = createTextElement('span', '', '输入内容后这里会实时显示高亮...');
+    placeholder.style.color = '#ccc';
+    output.replaceChildren(placeholder);
     document.getElementById('stat-vague').textContent = '0';
     document.getElementById('stat-filler').textContent = '0';
     document.getElementById('stat-hedge').textContent = '0';
     return;
   }
-  
-  let html = text;
-  let vagueCount = 0, fillerCount = 0, hedgeCount = 0;
-  
-  // 按长度排序（长词优先匹配，避免"我觉得"被"觉得"先匹配）
-  const allTier1 = Object.keys(tier1Map).sort((a, b) => b.length - a.length);
-  const allFillers = [...FILLER_WORDS].sort((a, b) => b.length - a.length);
-  const allHedges = [...HEDGE_WORDS].sort((a, b) => b.length - a.length);
-  
-  // 标记替换（用占位符避免嵌套）
-  const markers = [];
-  let markerIdx = 0;
-  
-  // 先标记第一层词
-  for (const word of allTier1) {
-    const regex = new RegExp(word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
-    html = html.replace(regex, () => {
-      vagueCount++;
-      const id = `__M${markerIdx++}__`;
-      markers.push({ id, html: `<span class="highlight" data-word="${word}">${word}</span>` });
-      return id;
-    });
+
+  const fragment = document.createDocumentFragment();
+  const counts = { vague: 0, filler: 0, hedge: 0 };
+  let cursor = 0;
+  let plainStart = 0;
+
+  while (cursor < text.length) {
+    const matched = HIGHLIGHT_PATTERNS.find(item => text.startsWith(item.word, cursor));
+    if (!matched) {
+      cursor += 1;
+      continue;
+    }
+
+    if (cursor > plainStart) {
+      appendTextWithBreaks(fragment, text.slice(plainStart, cursor));
+    }
+
+    const span = createTextElement('span', matched.className, matched.word);
+    if (matched.type === 'vague') {
+      span.dataset.word = matched.word;
+      span.addEventListener('click', () => showCard(matched.word));
+    }
+    fragment.appendChild(span);
+    counts[matched.type] += 1;
+
+    cursor += matched.word.length;
+    plainStart = cursor;
   }
-  
-  // 标记填充词
-  for (const word of allFillers) {
-    const regex = new RegExp(word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
-    html = html.replace(regex, () => {
-      fillerCount++;
-      const id = `__M${markerIdx++}__`;
-      markers.push({ id, html: `<span class="highlight-filler">${word}</span>` });
-      return id;
-    });
+
+  if (plainStart < text.length) {
+    appendTextWithBreaks(fragment, text.slice(plainStart));
   }
-  
-  // 标记犹豫词
-  for (const word of allHedges) {
-    const regex = new RegExp(word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
-    html = html.replace(regex, () => {
-      hedgeCount++;
-      const id = `__M${markerIdx++}__`;
-      markers.push({ id, html: `<span class="highlight-hedge">${word}</span>` });
-      return id;
-    });
-  }
-  
-  // 替换占位符
-  for (const m of markers) {
-    html = html.replace(m.id, m.html);
-  }
-  
-  // 换行处理
-  html = html.replace(/\n/g, '<br>');
-  
-  output.innerHTML = html;
-  document.getElementById('stat-vague').textContent = vagueCount;
-  document.getElementById('stat-filler').textContent = fillerCount;
-  document.getElementById('stat-hedge').textContent = hedgeCount;
-  
-  // 绑定点击事件
-  output.querySelectorAll('.highlight').forEach(el => {
-    el.addEventListener('click', () => showCard(el.dataset.word));
-  });
+
+  output.replaceChildren(fragment);
+  document.getElementById('stat-vague').textContent = counts.vague;
+  document.getElementById('stat-filler').textContent = counts.filler;
+  document.getElementById('stat-hedge').textContent = counts.hedge;
 });
 
 // ===== 替换卡片 =====
 function showCard(word) {
   const info = tier1Map[word];
   if (!info) return;
-  
-  cardsDiv.innerHTML = `
-    <div class="replacement-card">
-      <div class="original">你说了：</div>
-      <div class="word">「${word}」</div>
-      <div class="category">${info.category}</div>
-      <div class="alternatives">
-        ${info.alternatives.map(alt => `<span class="alt-chip">${alt}</span>`).join('')}
-      </div>
-    </div>
-  `;
+
+  const card = document.createElement('div');
+  card.className = 'replacement-card';
+  card.appendChild(createTextElement('div', 'original', '你说了：'));
+  card.appendChild(createTextElement('div', 'word', `「${word}」`));
+  card.appendChild(createTextElement('div', 'category', info.category));
+
+  const alternatives = document.createElement('div');
+  alternatives.className = 'alternatives';
+  info.alternatives.forEach(alt => {
+    alternatives.appendChild(createTextElement('span', 'alt-chip', alt));
+  });
+  card.appendChild(alternatives);
+  cardsDiv.replaceChildren(card);
 }
 
 // ===== 词库浏览 =====
 function renderLexiconBrowser() {
   const container = document.getElementById('lexicon-list');
-  let html = '';
-  
+  const fragment = document.createDocumentFragment();
+
   for (const [cat, words] of Object.entries(TIERED_LEXICON)) {
     if (cat === '_meta') continue;
     const catName = CATEGORY_NAMES[cat] || cat;
-    
-    html += `<div class="category-section">
-      <h3>${catName}（${Object.keys(words).length}词）</h3>
-      <div class="word-grid">`;
-    
+
+    const section = document.createElement('div');
+    section.className = 'category-section';
+    section.appendChild(createTextElement('h3', '', `${catName}（${Object.keys(words).length}词）`));
+
+    const grid = document.createElement('div');
+    grid.className = 'word-grid';
     for (const [word, alts] of Object.entries(words)) {
-      html += `<div class="word-item">
-        <span class="w-word">${word}</span>
-        <span class="w-arrow">→</span>
-        <span class="w-alts">${alts.slice(0, 3).join(' / ')}</span>
-      </div>`;
+      const item = document.createElement('div');
+      item.className = 'word-item';
+      item.appendChild(createTextElement('span', 'w-word', word));
+      item.appendChild(createTextElement('span', 'w-arrow', '→'));
+      item.appendChild(createTextElement('span', 'w-alts', alts.slice(0, 3).join(' / ')));
+      grid.appendChild(item);
     }
-    
-    html += '</div></div>';
+
+    section.appendChild(grid);
+    fragment.appendChild(section);
   }
-  
-  container.innerHTML = html;
+
+  container.replaceChildren(fragment);
 }
 
 renderLexiconBrowser();

--- a/src/settings.js
+++ b/src/settings.js
@@ -93,7 +93,7 @@ class SettingsPage {
     }
 
     // 填充模型列表
-    this.modelSelect.innerHTML = '';
+    this.modelSelect.replaceChildren();
     if (config.models.length > 0) {
       config.models.forEach(m => {
         const opt = document.createElement('option');

--- a/src/styles.css
+++ b/src/styles.css
@@ -282,6 +282,7 @@ button, input, select, .subtitle-scroll, .feedback-content, .modal-body {
   line-height: 1.9;
   color: #ddd;
 }
+.modal-body h1 { color: #E5007E; margin-top: 20px; margin-bottom: 10px; font-size: 18px; }
 .modal-body h2 { color: #E5007E; margin-top: 20px; margin-bottom: 8px; font-size: 16px; }
 .modal-body h3 { color: #fff; margin-top: 14px; font-size: 14px; }
 .modal-body blockquote { border-left: 3px solid #E5007E; padding-left: 12px; color: #999; margin: 8px 0; }
@@ -289,6 +290,9 @@ button, input, select, .subtitle-scroll, .feedback-content, .modal-body {
 .modal-body table { width: 100%; border-collapse: collapse; margin: 8px 0; }
 .modal-body th, .modal-body td { border: 1px solid #333; padding: 6px 10px; text-align: left; font-size: 13px; }
 .modal-body th { background: #1a1a1a; color: #E5007E; }
+.report-content p { margin: 4px 0; }
+.report-content ul { margin: 6px 0; padding-left: 22px; }
+.report-content hr { border: 0; border-top: 1px solid #333; margin: 16px 0; }
 
 /* 滚动条 */
 ::-webkit-scrollbar { width: 5px; }


### PR DESCRIPTION
## 背景

应用此前在转写文本、AI 分析报告和词库工具等位置通过 `innerHTML` 渲染动态内容。由于这些内容可能来自用户输入或外部 API，恶意 HTML 有机会被浏览器解析，在 Electron 环境中会扩大 XSS 风险。

## 本次改动

- 移除 `src/app.js`、`src/lexicon-playground.html` 和 `src/settings.js` 中的 `innerHTML` 用法。
- 使用 `textContent`、`createElement`、`DocumentFragment` 和 `replaceChildren` 安全构建 DOM。
- 为 AI 报告实现受限的 Markdown DOM 渲染，保留标题、列表、表格、引用、粗体和行内代码等展示能力，所有外部文本均通过文本节点写入。
- 调整报告样式，保持原有阅读体验。
- 同步清理 `package-lock.json` 中已不在 `package.json` 内的 `node-microphone` 残留依赖。

## 安全收益

AI 返回内容、粘贴的转写文本以及词库输入中的 HTML 标签和事件属性将被当作普通文本处理，不再作为可执行 DOM 注入页面。

## 验证

- `node --check` 通过主进程、预加载脚本及 `src` 下 JavaScript 的语法检查。
- 扫描确认 `src` 中不再包含 `innerHTML`、`outerHTML`、`insertAdjacentHTML`、`document.write`、`createContextualFragment` 或 `setHTMLUnsafe`。
- `git diff --check` 通过。
- 使用包含 `<img onerror>`、`<svg onload>` 和 `<script>` 的测试输入验证：内容仅作为文本显示，不会创建对应危险节点或执行脚本。
