### PR TITLE
feat: switch ASR to Zipformer Chinese and fix sample rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## 功能
 
-- 🎤 **实时语音识别**：基于 Sherpa-ONNX，完全离线，中文优化
+- 🎤 **实时语音识别**：基于 Sherpa-ONNX Zipformer，完全离线，中文优化
 - 📝 **全屏字幕显示**：黑底大字，实时显示你说的每一句话
 - 🔍 **词库分析**：自动检测填充词、犹豫词、笼统词，给出精准替代
 - 🤖 **AI反馈**：支持 Groq/OpenAI/DeepSeek/Ollama 多后端
@@ -21,25 +21,24 @@ npm install
 
 ### 2. 下载语音识别模型
 
-需要下载 Sherpa-ONNX 的 streaming paraformer 中英双语模型：
+需要下载 Sherpa-ONNX 的 streaming Zipformer 中文模型：
 
 ```bash
 cd models
 
-# 方法一：使用 wget
-wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-paraformer-bilingual-zh-en.tar.bz2
-tar xvf sherpa-onnx-streaming-paraformer-bilingual-zh-en.tar.bz2
-
-# 方法二：使用 huggingface
-# https://huggingface.co/csukuangfj/sherpa-onnx-streaming-paraformer-bilingual-zh-en
+wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30.tar.bz2
+tar xvf sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30.tar.bz2
+rm sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30.tar.bz2
 ```
 
 下载后 `models/` 目录应包含：
+
 ```
 models/
-└── sherpa-onnx-streaming-paraformer-bilingual-zh-en/
+└── sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30/
     ├── encoder.int8.onnx
-    ├── decoder.int8.onnx
+    ├── decoder.onnx
+    ├── joiner.int8.onnx
     └── tokens.txt
 ```
 ### 3. 启动应用

--- a/lib/asr.js
+++ b/lib/asr.js
@@ -1,6 +1,6 @@
 /**
  * 语音识别模块 - 基于 sherpa-onnx-node
- * 使用 streaming recognizer 实现实时中文语音识别
+ * 使用 streaming Zipformer transducer 实现实时中文语音识别
  * 录音通过 Electron 渲染进程的 Web Audio API 采集，音频数据通过 IPC 传入
  */
 
@@ -12,14 +12,20 @@ let stream = null;
 let isRunning = false;
 
 const MODELS_DIR = path.join(__dirname, '..', 'models');
-const MODEL_SUBDIR = 'sherpa-onnx-streaming-paraformer-bilingual-zh-en';
+const MODEL_SUBDIR = 'sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30';
+const TARGET_SAMPLE_RATE = 16000;
 
 /**
  * 检查模型文件是否存在
  */
 function checkModels() {
   const modelDir = path.join(MODELS_DIR, MODEL_SUBDIR);
-  const files = ['encoder.int8.onnx', 'decoder.int8.onnx', 'tokens.txt'];
+  const files = [
+    'encoder.int8.onnx',
+    'decoder.onnx',
+    'joiner.int8.onnx',
+    'tokens.txt'
+  ];
 
   for (const file of files) {
     const fullPath = path.join(modelDir, file);
@@ -51,13 +57,14 @@ async function initASR() {
 
   const config = {
     featConfig: {
-      sampleRate: 16000,
+      sampleRate: TARGET_SAMPLE_RATE,
       featureDim: 80
     },
     modelConfig: {
-      paraformer: {
+      transducer: {
         encoder: path.join(modelDir, 'encoder.int8.onnx'),
-        decoder: path.join(modelDir, 'decoder.int8.onnx'),
+        decoder: path.join(modelDir, 'decoder.onnx'),
+        joiner: path.join(modelDir, 'joiner.int8.onnx')
       },
       tokens: path.join(modelDir, 'tokens.txt'),
       numThreads: 2,
@@ -76,19 +83,21 @@ async function initASR() {
   stream = recognizer.createStream();
   isRunning = true;
 
-  console.log('[ASR] 识别引擎初始化完成');
+  console.log('[ASR] Zipformer 中文识别引擎初始化完成');
 }
 
 /**
  * 接收渲染进程发来的音频数据进行识别
- * @param {Float32Array} samples - 16kHz 单声道音频采样
+ * @param {Float32Array} samples - 音频采样
+ * @param {number} [sampleRate=16000] - 实际采集采样率（与目标不一致时由 sherpa 重采样）
  * @returns {{ text: string, isFinal: boolean } | null}
  */
-function feedAudio(samples) {
+function feedAudio(samples, sampleRate = TARGET_SAMPLE_RATE) {
   if (!isRunning || !stream || !recognizer) return null;
 
+  const rate = Number(sampleRate) > 0 ? Number(sampleRate) : TARGET_SAMPLE_RATE;
   // sherpa-onnx-node API: acceptWaveform({ samples, sampleRate })
-  stream.acceptWaveform({ samples, sampleRate: 16000 });
+  stream.acceptWaveform({ samples, sampleRate: rate });
 
   while (recognizer.isReady(stream)) {
     recognizer.decode(stream);

--- a/main.js
+++ b/main.js
@@ -194,11 +194,11 @@ ipcMain.handle('init-asr', async () => {
   }
 });
 
-// 接收渲染进程发来的音频数据
-ipcMain.handle('feed-audio', (event, samplesArray) => {
+// 接收渲染进程发来的音频数据（sampleRate 为实际采集率，由 sherpa 内部重采样）
+ipcMain.handle('feed-audio', (event, samplesArray, sampleRate) => {
   if (!asrReady) return null;
   const samples = new Float32Array(samplesArray);
-  const result = feedAudio(samples);
+  const result = feedAudio(samples, sampleRate);
   return result; // { text, isFinal } or null
 });
 

--- a/preload.js
+++ b/preload.js
@@ -14,7 +14,7 @@ contextBridge.exposeInMainWorld('api', {
 
   // 语音识别 - 使用 Web Audio 方案
   initASR: () => ipcRenderer.invoke('init-asr'),
-  feedAudio: (samples) => ipcRenderer.invoke('feed-audio', Array.from(samples)),
+  feedAudio: (samples, sampleRate) => ipcRenderer.invoke('feed-audio', Array.from(samples), sampleRate),
   stopASR: () => ipcRenderer.invoke('stop-asr'),
   onASRResult: (callback) => {
     ipcRenderer.on('asr-result', (event, data) => callback(data));

--- a/src/app.js
+++ b/src/app.js
@@ -81,14 +81,23 @@ class ExpressionTrainer {
     }
 
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true
+        }
+      });
+      // 请求 16kHz；macOS 可能仍用设备采样率，需把实际采样率传给 ASR
       this.audioContext = new AudioContext({ sampleRate: 16000 });
+      const captureRate = this.audioContext.sampleRate;
+      console.log(`[Audio] 实际采样率=${captureRate}`);
       const source = this.audioContext.createMediaStreamSource(stream);
       this.audioProcessor = this.audioContext.createScriptProcessor(4096, 1, 1);
       this.audioProcessor.onaudioprocess = async (e) => {
         if (!this.isRecording || this.isPaused) return;
         const samples = e.inputBuffer.getChannelData(0);
-        const result = await window.api.feedAudio(samples);
+        const result = await window.api.feedAudio(samples, captureRate);
         if (result) this.handleASRResult(result);
       };
       source.connect(this.audioProcessor);


### PR DESCRIPTION
## Summary

- 将 streaming Paraformer 中英双语 ASR 替换为 **Zipformer 中文 int8（2025-06-30）**，减轻中文叠字
- 把真实 `AudioContext` 采样率传入 sherpa，避免 macOS 设备采样率（常为 48kHz）被当成 16kHz

## Test plan

- [ ] 按 README 下载新模型到 `models/`
- [ ] `npm install` 后 `npm start`
- [ ] 说一段中文，确认字幕无明显「我我 / 这个这个」叠字
- [ ] 确认填充词高亮与实时反馈仍正常


Made with [Cursor](https://cursor.com)