### PR TITLE
Add persistent coaching memory and anchored feedback

### DIFF
--- a/lib/ai-feedback.js
+++ b/lib/ai-feedback.js
@@ -3,7 +3,7 @@
  * 支持 DeepSeek / OpenAI / Ollama / 自定义 OpenAI 兼容接口
  */
 
-const { getRealtimePrompt, getReportPrompt } = require('./prompts');
+const { getRealtimePrompt, getReportPrompt, getMemoryExtractionPrompt } = require('./prompts');
 
 // 各后端的 API 配置
 const PROVIDER_ENDPOINTS = {
@@ -86,9 +86,9 @@ function getProviderConfig(settings) {
  * @param {Object} settings - 用户设置
  * @returns {string} 反馈HTML
  */
-async function sendFeedback(text, settings, customPrompt) {
+async function sendFeedback(text, settings, customPrompt, context) {
   const config = getProviderConfig(settings);
-  const prompt = getRealtimePrompt(text, null, customPrompt);
+  const prompt = getRealtimePrompt(text, context, customPrompt);
 
   const messages = [
     { role: 'system', content: prompt.system },
@@ -106,9 +106,9 @@ async function sendFeedback(text, settings, customPrompt) {
  * @param {Object} settings - 用户设置
  * @returns {string} 报告文本
  */
-async function sendReport(fullText, stats, settings, customPrompt) {
+async function sendReport(fullText, stats, settings, customPrompt, longTermProfile) {
   const config = getProviderConfig(settings);
-  const prompt = getReportPrompt(fullText, stats, customPrompt);
+  const prompt = getReportPrompt(fullText, stats, customPrompt, longTermProfile);
 
   const messages = [
     { role: 'system', content: prompt.system },
@@ -117,6 +117,63 @@ async function sendReport(fullText, stats, settings, customPrompt) {
 
   const result = await callAPI(config.endpoint, config.apiKey, config.model, messages, 8192);
   return result;
+}
+
+function parseMemoryJSON(text) {
+  const cleaned = String(text || '')
+    .trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/, '');
+  const start = cleaned.indexOf('{');
+  const end = cleaned.lastIndexOf('}');
+  if (start < 0 || end <= start) throw new Error('记忆提炼未返回 JSON');
+  const parsed = JSON.parse(cleaned.slice(start, end + 1));
+  return normalizeMemoryInsight(parsed);
+}
+
+function normalizeMemoryInsight(data) {
+  const problemCategories = new Set([
+    'conclusion_late', 'filler_words', 'hedging', 'vague_language', 'repetition',
+    'topic_drift', 'lack_examples', 'weak_structure', 'unclear_expression', 'pacing', 'other'
+  ]);
+  const strengthCategories = new Set([
+    'clear_conclusion', 'strong_structure', 'vivid_examples', 'strong_imagery',
+    'concise_language', 'confident_tone', 'engaging_hook', 'other'
+  ]);
+  const clamp = value => Math.max(0, Math.min(1, Number(value) || 0));
+  const clean = value => String(value || '').trim().slice(0, 300);
+  const normalizeProblem = item => ({
+    category: problemCategories.has(item?.category) ? item.category : 'other',
+    summary: clean(item?.summary),
+    evidence: clean(item?.evidence),
+    confidence: clamp(item?.confidence)
+  });
+
+  return {
+    mainProblem: normalizeProblem(data?.mainProblem || {}),
+    patterns: (Array.isArray(data?.patterns) ? data.patterns : []).slice(0, 3).map(normalizeProblem),
+    strengths: (Array.isArray(data?.strengths) ? data.strengths : []).slice(0, 3).map(item => ({
+      category: strengthCategories.has(item?.category) ? item.category : 'other',
+      summary: clean(item?.summary),
+      evidence: clean(item?.evidence)
+    })),
+    recommendedDrill: {
+      name: clean(data?.recommendedDrill?.name),
+      instruction: clean(data?.recommendedDrill?.instruction),
+      successMetric: clean(data?.recommendedDrill?.successMetric)
+    }
+  };
+}
+
+async function extractMemoryInsight(fullText, report, stats, settings) {
+  const config = getProviderConfig(settings);
+  const prompt = getMemoryExtractionPrompt(fullText, report, stats);
+  const messages = [
+    { role: 'system', content: prompt.system },
+    { role: 'user', content: prompt.user }
+  ];
+  const result = await callAPI(config.endpoint, config.apiKey, config.model, messages, 900);
+  return parseMemoryJSON(result);
 }
 
 /**
@@ -133,4 +190,4 @@ function formatFeedback(text) {
   return html;
 }
 
-module.exports = { sendFeedback, sendReport };
+module.exports = { sendFeedback, sendReport, extractMemoryInsight, parseMemoryJSON, normalizeMemoryInsight };

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -22,6 +22,9 @@ function getRealtimePrompt(text, context, customPrompt) {
   const elapsedMin = Math.floor(elapsed / 60);
   const topic = context?.topic || '';
   const prevPoints = context?.previousPoints || [];
+  const currentFocus = context?.currentFocus || '';
+  const longTermProfile = context?.longTermProfile || null;
+  const currentSentence = context?.currentSentence || text.slice(-150);
 
   // 拼接用户自定义规则
   let customBlock = '';
@@ -44,11 +47,15 @@ function getRealtimePrompt(text, context, customPrompt) {
   if (elapsedMin > 0) contextBlock += `[已说${elapsedMin}分钟] `;
   if (topic) contextBlock += `[开头主题: "${topic}"] `;
   if (prevPoints.length > 0) contextBlock += `[已说过的观点: ${prevPoints.join(';')}]`;
+  if (currentFocus) contextBlock += ` [本次训练重点: ${currentFocus}]`;
+  if (longTermProfile?.frequentFillers?.length) {
+    contextBlock += ` [历史高频口癖: ${longTermProfile.frequentFillers.map(item => item.word).join('、')}]`;
+  }
 
   const result = {
     system: `你是中文口语表达的实时教练。每次只输出1条提示，不超过8个字，不加标点，不解释。
 
-你的职责：根据最新这段话，判断是否触发以下任一规则。触发了输出对应提示。都没触发输出空行。
+你的职责：只评价用户标明的“当前原句”。历史语境只用于判断重复、跑题和前后矛盾，不要把历史句子的问题挂到当前原句上。触发了输出对应提示，都没触发输出空行。
 
 ## 触发规则（按优先级排序，只输出第一个命中的）
 
@@ -71,7 +78,7 @@ function getRealtimePrompt(text, context, customPrompt) {
 - 如果都没触发，输出一个空行
 - 不管错别字、不管语音识别错误`,
 
-    user: `${contextBlock}\n\n最新一段：\n"${text.slice(-500)}"`
+    user: `${contextBlock}\n\n历史语境（仅供参考）：\n"${text.slice(-500)}"\n\n当前原句（只评价这一句）：\n"${currentSentence}"`
   };
 
   // 合并用户自定义内容到system prompt末尾
@@ -86,7 +93,7 @@ function getRealtimePrompt(text, context, customPrompt) {
  * 结束报告 Prompt(完整版)
  * 融合 meeting-insights-analyzer 的行为模式分析 + content-research-writer 的逐句编辑
  */
-function getReportPrompt(fullText, stats, customPrompt) {
+function getReportPrompt(fullText, stats, customPrompt, longTermProfile) {
   const result = {
     system: `你是专业中文表达教练,融合了两套核心能力:
 
@@ -217,7 +224,11 @@ function getReportPrompt(fullText, stats, customPrompt) {
 ${fullText}
 ---
 
-数据:${stats.duration}秒 | ${stats.totalWords}字 | 填充词${stats.fillers}次 | 犹豫词${stats.hedges}次 | 笼统词${stats.vagueWords}次`
+数据:${stats.duration}秒 | ${stats.totalWords}字 | 填充词${stats.fillers}次 | 犹豫词${stats.hedges}次 | 笼统词${stats.vagueWords}次
+
+长期训练画像:${longTermProfile?.totalSessions || 0}次历史训练 | 当前重点:${longTermProfile?.currentFocus || '尚未建立'} | 历史高频口癖:${(longTermProfile?.frequentFillers || []).map(item => `${item.word}(${item.count})`).join('、') || '暂无'} | 稳定模式:${(longTermProfile?.stablePatterns || []).map(item => `${item.summary}(出现${item.occurrences}次)`).join('；') || '暂无'}
+
+请在报告中区分“本次偶发问题”和“历史稳定模式”，不要根据单次表现武断地定义用户。`
   };
 
   // 合并用户自定义内容到report system prompt末尾
@@ -240,4 +251,56 @@ ${fullText}
   return result;
 }
 
-module.exports = { getRealtimePrompt, getReportPrompt };
+function getMemoryExtractionPrompt(fullText, report, stats) {
+  return {
+    system: `你是表达训练记忆提炼器。你的任务不是再写一份报告，而是把报告提炼成可以跨多次训练比较的结构化记忆。
+
+只输出合法 JSON，不要 markdown，不要代码块，不要解释。JSON 结构必须为：
+{
+  "mainProblem": {
+    "category": "问题类型",
+    "summary": "一句话概括",
+    "evidence": "来自原文的简短证据",
+    "confidence": 0.0
+  },
+  "patterns": [
+    {
+      "category": "问题类型",
+      "summary": "可比较的行为描述",
+      "evidence": "来自原文的简短证据",
+      "confidence": 0.0
+    }
+  ],
+  "strengths": [
+    { "category": "优势类型", "summary": "一句话概括", "evidence": "简短证据" }
+  ],
+  "recommendedDrill": {
+    "name": "练习名称",
+    "instruction": "可直接执行的练习方法",
+    "successMetric": "下次如何判断达标"
+  }
+}
+
+问题 category 只能从以下枚举中选择：
+conclusion_late, filler_words, hedging, vague_language, repetition, topic_drift, lack_examples, weak_structure, unclear_expression, pacing, other
+
+优势 category 只能从以下枚举中选择：
+clear_conclusion, strong_structure, vivid_examples, strong_imagery, concise_language, confident_tone, engaging_hook, other
+
+约束：
+- patterns 最多 3 条，strengths 最多 3 条
+- confidence 是 0 到 1 的数字
+- 证据必须来自本次原文，不能将模型推测当成事实
+- 不要把单次问题表述成用户永久性格
+- 如果证据不足，降低 confidence`,
+    user: `本次数据：${stats.duration || 0}秒 | ${stats.totalWords || fullText.length}字 | 填充词${stats.fillers || 0}次 | 犹豫词${stats.hedges || 0}次 | 笼统词${stats.vagueWords || 0}次
+
+本次原文：
+${fullText}
+
+教练报告：
+${report}`
+  };
+}
+
+module.exports = { getRealtimePrompt, getReportPrompt, getMemoryExtractionPrompt };

--- a/lib/training-memory.js
+++ b/lib/training-memory.js
@@ -1,0 +1,199 @@
+const fs = require('fs');
+const path = require('path');
+
+const MAX_SESSIONS = 100;
+
+function emptyMemory() {
+  return {
+    version: 2,
+    sessions: [],
+    profile: {
+      totalSessions: 0,
+      frequentFillers: [],
+      frequentHedges: [],
+      averages: { fillersPerKChars: 0, hedgesPerKChars: 0, vaguePerKChars: 0, density: 100 },
+      stablePatterns: [],
+      observedPatterns: [],
+      strengths: [],
+      recommendedDrill: null,
+      currentFocus: '完成第一次训练，建立你的表达基线',
+      updatedAt: null
+    }
+  };
+}
+
+function loadMemory(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return emptyMemory();
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    return { ...emptyMemory(), ...data, profile: { ...emptyMemory().profile, ...(data.profile || {}) } };
+  } catch (error) {
+    console.warn('[记忆] 训练记录读取失败，将使用空记录:', error.message);
+    return emptyMemory();
+  }
+}
+
+function countWords(items = []) {
+  const counts = new Map();
+  items.forEach(item => {
+    const word = typeof item === 'string' ? item : item.word;
+    if (word) counts.set(word, (counts.get(word) || 0) + 1);
+  });
+  return counts;
+}
+
+function mergeCounts(target, source) {
+  source.forEach((count, word) => target.set(word, (target.get(word) || 0) + count));
+}
+
+function topWords(counts, limit = 5) {
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([word, count]) => ({ word, count }));
+}
+
+function round(value) {
+  return Math.round((Number(value) || 0) * 10) / 10;
+}
+
+function deriveProfile(sessions) {
+  if (!sessions.length) return emptyMemory().profile;
+
+  const recent = sessions.slice(-10);
+  const fillerCounts = new Map();
+  const hedgeCounts = new Map();
+  let chars = 0;
+  let fillers = 0;
+  let hedges = 0;
+  let vague = 0;
+  let densityTotal = 0;
+
+  recent.forEach(session => {
+    const sessionChars = Math.max(session.textLength || session.stats?.totalWords || 0, 1);
+    chars += sessionChars;
+    fillers += session.stats?.fillers || 0;
+    hedges += session.stats?.hedges || 0;
+    vague += session.stats?.vagueWords || 0;
+    densityTotal += session.stats?.density ?? 100;
+    mergeCounts(fillerCounts, countWords(session.fillerWords));
+    mergeCounts(hedgeCounts, countWords(session.hedgeWords));
+  });
+
+  const rates = {
+    fillersPerKChars: round(fillers / chars * 1000),
+    hedgesPerKChars: round(hedges / chars * 1000),
+    vaguePerKChars: round(vague / chars * 1000),
+    density: round(densityTotal / recent.length)
+  };
+
+  const patternMap = new Map();
+  const strengthMap = new Map();
+  recent.forEach(session => {
+    const insight = session.structuredMemory;
+    if (!insight) return;
+
+    const sessionPatterns = [insight.mainProblem, ...(insight.patterns || [])]
+      .filter(item => item?.category && item.confidence >= 0.45);
+    const seenCategories = new Set();
+    sessionPatterns.forEach(item => {
+      if (seenCategories.has(item.category)) return;
+      seenCategories.add(item.category);
+      const current = patternMap.get(item.category) || {
+        category: item.category,
+        occurrences: 0,
+        confidenceTotal: 0,
+        summary: '',
+        latestEvidence: ''
+      };
+      current.occurrences += 1;
+      current.confidenceTotal += item.confidence;
+      current.summary = item.summary || current.summary;
+      current.latestEvidence = item.evidence || current.latestEvidence;
+      patternMap.set(item.category, current);
+    });
+
+    (insight.strengths || []).forEach(item => {
+      if (!item?.category) return;
+      const current = strengthMap.get(item.category) || { category: item.category, occurrences: 0, summary: '' };
+      current.occurrences += 1;
+      current.summary = item.summary || current.summary;
+      strengthMap.set(item.category, current);
+    });
+  });
+
+  const observedPatterns = [...patternMap.values()]
+    .map(item => ({
+      category: item.category,
+      occurrences: item.occurrences,
+      confidence: round(item.confidenceTotal / item.occurrences),
+      summary: item.summary,
+      latestEvidence: item.latestEvidence,
+      status: item.occurrences >= 2 ? 'stable' : 'observed'
+    }))
+    .sort((a, b) => b.occurrences - a.occurrences || b.confidence - a.confidence);
+  const stablePatterns = observedPatterns.filter(item => item.status === 'stable');
+  const strengths = [...strengthMap.values()]
+    .sort((a, b) => b.occurrences - a.occurrences)
+    .slice(0, 5);
+
+  const candidates = [
+    { key: 'fillersPerKChars', score: rates.fillersPerKChars / 20, text: '用停顿替代填充词' },
+    { key: 'hedgesPerKChars', score: rates.hedgesPerKChars / 12, text: '减少犹豫词，先说明确结论' },
+    { key: 'vaguePerKChars', score: rates.vaguePerKChars / 18, text: '把笼统表达换成数字和例子' }
+  ].sort((a, b) => b.score - a.score);
+
+  const latestInsight = [...recent].reverse().find(session => session.structuredMemory)?.structuredMemory;
+  const memoryFocus = stablePatterns[0]?.summary || latestInsight?.mainProblem?.summary;
+  const fallbackFocus = candidates[0].score > 0 ? candidates[0].text : '先说结论，再给理由和例子';
+
+  return {
+    totalSessions: sessions.length,
+    frequentFillers: topWords(fillerCounts),
+    frequentHedges: topWords(hedgeCounts),
+    averages: rates,
+    stablePatterns,
+    observedPatterns,
+    strengths,
+    recommendedDrill: latestInsight?.recommendedDrill || null,
+    currentFocus: memoryFocus || fallbackFocus,
+    updatedAt: new Date().toISOString()
+  };
+}
+
+function saveSession(filePath, session) {
+  const memory = loadMemory(filePath);
+  const normalized = {
+    id: session.id || `${Date.now()}`,
+    createdAt: session.createdAt || new Date().toISOString(),
+    source: session.source || 'recording',
+    topic: session.topic || '',
+    textLength: session.textLength || 0,
+    stats: session.stats || {},
+    fillerWords: session.fillerWords || [],
+    hedgeWords: session.hedgeWords || [],
+    focus: session.focus || '',
+    reportSummary: session.reportSummary || '',
+    structuredMemory: session.structuredMemory || null
+  };
+
+  const existingIndex = memory.sessions.findIndex(item => item.id === normalized.id);
+  if (existingIndex >= 0) memory.sessions[existingIndex] = normalized;
+  else memory.sessions.push(normalized);
+
+  memory.sessions = memory.sessions.slice(-MAX_SESSIONS);
+  memory.profile = deriveProfile(memory.sessions);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(memory, null, 2), 'utf-8');
+  return memory;
+}
+
+function getMemorySummary(filePath) {
+  const memory = loadMemory(filePath);
+  return {
+    profile: memory.profile,
+    recentSessions: memory.sessions.slice(-5).reverse()
+  };
+}
+
+module.exports = { loadMemory, saveSession, getMemorySummary, deriveProfile };

--- a/main.js
+++ b/main.js
@@ -3,7 +3,8 @@ const path = require('path');
 const fs = require('fs');
 const { initASR, feedAudio, stopRecognition } = require('./lib/asr');
 const { loadLexicon, analyzeText } = require('./lib/lexicon');
-const { sendFeedback, sendReport } = require('./lib/ai-feedback');
+const { sendFeedback, sendReport, extractMemoryInsight } = require('./lib/ai-feedback');
+const { getMemorySummary, saveSession } = require('./lib/training-memory');
 
 let mainWindow;
 let settingsWindow;
@@ -30,6 +31,10 @@ function saveCustomPrompt(data) {
 // 设置文件路径
 function getSettingsPath() {
   return path.join(app.getPath('userData'), 'settings.json');
+}
+
+function getTrainingMemoryPath() {
+  return path.join(app.getPath('userData'), 'training-memory.json');
 }
 
 function loadSettings() {
@@ -213,6 +218,10 @@ ipcMain.handle('analyze-text', (event, text) => {
   return analyzeText(text);
 });
 
+ipcMain.handle('get-training-memory', () => {
+  return getMemorySummary(getTrainingMemoryPath());
+});
+
 // 文件保存
 ipcMain.handle('save-file', async (event, content, filename) => {
   const { dialog } = require('electron');
@@ -230,23 +239,47 @@ ipcMain.handle('save-file', async (event, content, filename) => {
 });
 
 // AI反馈（传入customPrompt）
-ipcMain.handle('get-realtime-feedback', async (event, text) => {
+ipcMain.handle('get-realtime-feedback', async (event, payload) => {
   const settings = loadSettings();
   const customPrompt = loadCustomPrompt();
+  const memory = getMemorySummary(getTrainingMemoryPath());
+  const data = typeof payload === 'string' ? { text: payload } : payload;
   try {
-    const feedback = await sendFeedback(text, settings, customPrompt);
+    const feedback = await sendFeedback(data.text, settings, customPrompt, {
+      elapsedSec: data.elapsedSec,
+      topic: data.topic,
+      previousPoints: data.previousPoints,
+      currentSentence: data.currentSentence,
+      currentFocus: memory.profile.currentFocus,
+      longTermProfile: memory.profile
+    });
     return { success: true, feedback };
   } catch (error) {
     return { success: false, error: error.message };
   }
 });
 
-ipcMain.handle('get-final-report', async (event, { fullText, stats }) => {
+ipcMain.handle('get-final-report', async (event, { fullText, stats, session }) => {
   const settings = loadSettings();
   const customPrompt = loadCustomPrompt();
+  const memoryPath = getTrainingMemoryPath();
+  const memory = getMemorySummary(memoryPath);
   try {
-    const report = await sendReport(fullText, stats, settings, customPrompt);
-    return { success: true, report };
+    const report = await sendReport(fullText, stats, settings, customPrompt, memory.profile);
+    let structuredMemory = null;
+    try {
+      structuredMemory = await extractMemoryInsight(fullText, report, stats, settings);
+    } catch (memoryError) {
+      console.warn('[记忆] 报告结构化提炼失败，不影响报告使用:', memoryError.message);
+    }
+    const updatedMemory = saveSession(memoryPath, {
+      ...session,
+      textLength: fullText.length,
+      stats,
+      reportSummary: report.slice(0, 500),
+      structuredMemory
+    });
+    return { success: true, report, profile: updatedMemory.profile, memoryExtracted: Boolean(structuredMemory) };
   } catch (error) {
     return { success: false, error: error.message };
   }

--- a/preload.js
+++ b/preload.js
@@ -25,6 +25,7 @@ contextBridge.exposeInMainWorld('api', {
 
   // 词库分析
   analyzeText: (text) => ipcRenderer.invoke('analyze-text', text),
+  getTrainingMemory: () => ipcRenderer.invoke('get-training-memory'),
 
   // AI反馈
   getRealtimeFeedback: (text) => ipcRenderer.invoke('get-realtime-feedback', text),

--- a/src/app.js
+++ b/src/app.js
@@ -13,9 +13,17 @@ class ExpressionTrainer {
     this.stats = { fillers: 0, hedges: 0, vagueWords: 0, totalWords: 0, duration: 0 };
     this.lastFeedbackText = '';
     this.lastReport = '';
+    this.sessionId = null;
+    this.sessionSource = 'recording';
+    this.fillerWords = [];
+    this.hedgeWords = [];
+    this.feedbackRequestPending = false;
+    this.feedbackEvents = [];
+    this.feedbackEventId = 0;
 
     this.initElements();
     this.bindEvents();
+    this.loadTrainingMemory();
   }
 
   initElements() {
@@ -39,12 +47,15 @@ class ExpressionTrainer {
     this.subtitleScroll = document.getElementById('subtitle-scroll');
     this.subtitleContainer = document.getElementById('subtitle-container');
     this.feedbackContent = document.getElementById('feedback-content');
+    this.feedbackHint = document.getElementById('feedback-hint');
     this.reportModal = document.getElementById('report-modal');
     this.reportBody = document.getElementById('report-body');
     this.statFillers = document.getElementById('stat-fillers');
     this.statHedges = document.getElementById('stat-hedges');
     this.statVague = document.getElementById('stat-vague');
     this.statDensity = document.getElementById('stat-density');
+    this.memorySessionCount = document.getElementById('memory-session-count');
+    this.memoryCurrentFocus = document.getElementById('memory-current-focus');
   }
 
   bindEvents() {
@@ -105,6 +116,8 @@ class ExpressionTrainer {
     this.pausedTime = 0;
     this.fullText = '';
     this.sentences = [];
+    this.sessionId = `recording-${Date.now()}`;
+    this.sessionSource = 'recording';
     this.resetStats();
     this.subtitleContainer.innerHTML = '';
 
@@ -117,6 +130,7 @@ class ExpressionTrainer {
     this.timer.classList.add('active');
 
     this.timerInterval = setInterval(() => this.updateTimer(), 1000);
+    this.feedbackHint.textContent = '正在记录反馈，不用分心阅读';
   }
 
   pauseRecording() {
@@ -162,6 +176,8 @@ class ExpressionTrainer {
       this.btnSaveText.classList.remove('hidden');
       this.btnClear.classList.remove('hidden');
     }
+    this.feedbackHint.textContent = '点击任意反馈，自动定位并高亮对应原句';
+    this.renderFeedbackTimeline();
   }
 
   // ===== ASR结果处理 =====
@@ -170,7 +186,8 @@ class ExpressionTrainer {
     if (isFinal) {
       this.sentences.push(text);
       this.fullText += text;
-      this.analyzeCurrentSentence(text);
+      const sentenceIndex = this.sentences.length - 1;
+      this.analyzeCurrentSentence(text, sentenceIndex);
 
       // 每30字触发一次AI反馈（语境化精准词建议）
       if (this.fullText.length - this.lastFeedbackText.length >= 30) {
@@ -194,6 +211,7 @@ class ExpressionTrainer {
       // 新行
       const line = document.createElement('div');
       line.className = 'subtitle-line';
+      line.dataset.sentenceIndex = this.sentences.length - 1;
       line.innerHTML = this.highlightText(currentText);
       this.subtitleContainer.appendChild(line);
     } else {
@@ -225,30 +243,32 @@ class ExpressionTrainer {
 
   // ===== 分析 =====
 
-  async analyzeCurrentSentence(text) {
+  async analyzeCurrentSentence(text, sentenceIndex) {
     const analysis = await window.api.analyzeText(text);
     if (analysis) {
       this.stats.fillers += analysis.fillers.length;
       this.stats.hedges += analysis.hedges.length;
       this.stats.vagueWords += analysis.vagueWords.length;
       this.stats.totalWords += analysis.totalWords;
+      this.fillerWords.push(...analysis.fillers.map(item => item.word));
+      this.hedgeWords.push(...analysis.hedges.map(item => item.word));
       this.updateStatsDisplay();
       // 碰到笼统词 → 立刻在反馈栏弹出替换建议
       if (analysis.vagueWords && analysis.vagueWords.length > 0) {
         analysis.vagueWords.forEach(item => {
           const alts = item.alternatives.slice(0, 3).join(' / ');
-          this.addFeedbackItem(`「${item.word}」→ ${alts}`, 'vague');
+          this.addFeedbackItem(`「${item.word}」→ ${alts}`, 'vague', { sentenceIndex, excerpt: text });
         });
       }
       // 碰到填充词 → 弹提醒
       if (analysis.fillers && analysis.fillers.length >= 2) {
         const uniqueFillers = [...new Set(analysis.fillers.map(f => f.word))].slice(0, 3);
-        this.addFeedbackItem(`填充词：${uniqueFillers.join('、')}——试试停顿`, 'filler');
+        this.addFeedbackItem(`填充词：${uniqueFillers.join('、')}——试试停顿`, 'filler', { sentenceIndex, excerpt: text });
       }
       // 碰到犹豫词 → 弹提醒
       if (analysis.hedges && analysis.hedges.length >= 1) {
         const uniqueHedges = [...new Set(analysis.hedges.map(h => h.word))].slice(0, 2);
-        this.addFeedbackItem(`「${uniqueHedges.join('」「')}」→ 直接说`, 'hedge');
+        this.addFeedbackItem(`「${uniqueHedges.join('」「')}」→ 直接说`, 'hedge', { sentenceIndex, excerpt: text });
       }
     }
   }
@@ -258,22 +278,38 @@ class ExpressionTrainer {
     this.statHedges.textContent = this.stats.hedges;
     this.statVague.textContent = this.stats.vagueWords;
     if (this.stats.totalWords > 0) {
-      const density = ((this.stats.totalWords - this.stats.fillers - this.stats.hedges) / this.stats.totalWords * 100).toFixed(0);
-      this.statDensity.textContent = density + '%';
+      this.statDensity.textContent = this.calculateDensity() + '%';
     }
   }
 
   // ===== 实时反馈 =====
 
   async requestRealtimeFeedback() {
+    if (this.feedbackRequestPending || !this.fullText.trim()) return;
+    this.feedbackRequestPending = true;
     this.lastFeedbackText = this.fullText;
-    const result = await window.api.getRealtimeFeedback(this.fullText);
-    if (result.success && result.feedback) {
-      const lines = result.feedback.split('\n').filter(l => l.trim());
-      lines.forEach(line => {
-        const type = this.classifyFeedback(line.trim());
-        this.addFeedbackItem(line.trim(), type);
+    const anchor = {
+      sentenceIndex: Math.max(0, this.sentences.length - 1),
+      excerpt: this.sentences[this.sentences.length - 1] || this.fullText.slice(-100),
+      elapsedSec: this.getElapsedSeconds()
+    };
+    try {
+      const result = await window.api.getRealtimeFeedback({
+        text: this.fullText,
+        elapsedSec: this.getElapsedSeconds(),
+        topic: this.sentences[0]?.slice(0, 80) || '',
+        previousPoints: this.sentences.slice(-6, -1).map(item => item.slice(0, 80)),
+        currentSentence: anchor.excerpt
       });
+      if (result.success && result.feedback) {
+        const lines = result.feedback.split('\n').filter(l => l.trim());
+        lines.forEach(line => {
+          const type = this.classifyFeedback(line.trim());
+          this.addFeedbackItem(line.trim(), type, anchor);
+        });
+      }
+    } finally {
+      this.feedbackRequestPending = false;
     }
   }
 
@@ -290,18 +326,72 @@ class ExpressionTrainer {
     return 'ai';
   }
 
-  addFeedbackItem(text, type = 'ai') {
-    // 去重：如果前3条已经有相同内容，跳过
-    const existing = Array.from(this.feedbackContent.children).slice(0, 3);
-    if (existing.some(el => el.textContent === text)) return;
+  addFeedbackItem(text, type = 'ai', meta = {}) {
+    const recent = this.feedbackEvents.slice(-3);
+    if (recent.some(event => event.text === text && event.sentenceIndex === meta.sentenceIndex)) return;
 
-    const item = document.createElement('div');
-    item.className = `feedback-item type-${type}`;
-    item.textContent = text;
-    this.feedbackContent.insertBefore(item, this.feedbackContent.firstChild);
-    while (this.feedbackContent.children.length > 12) {
-      this.feedbackContent.removeChild(this.feedbackContent.lastChild);
+    this.feedbackEvents.push({
+      id: ++this.feedbackEventId,
+      text,
+      type,
+      sentenceIndex: Number.isInteger(meta.sentenceIndex) ? meta.sentenceIndex : Math.max(0, this.sentences.length - 1),
+      excerpt: (meta.excerpt || '').trim().slice(0, 100),
+      elapsedSec: Number.isFinite(meta.elapsedSec) ? meta.elapsedSec : this.getElapsedSeconds(),
+      positionLabel: meta.positionLabel || ''
+    });
+    this.renderFeedbackTimeline();
+  }
+
+  renderFeedbackTimeline() {
+    this.feedbackContent.innerHTML = '';
+    if (!this.feedbackEvents.length) return;
+
+    if (!this.isRecording) {
+      const labels = { vague: '笼统词', filler: '填充词', hedge: '犹豫词', ai: '结构建议', good: '亮点' };
+      const counts = this.feedbackEvents.reduce((result, event) => {
+        result[event.type] = (result[event.type] || 0) + 1;
+        return result;
+      }, {});
+      const summary = document.createElement('div');
+      summary.className = 'feedback-summary';
+      Object.entries(counts).forEach(([type, count]) => {
+        const chip = document.createElement('span');
+        chip.className = 'feedback-summary-chip';
+        chip.textContent = `${labels[type] || '其他'} ${count}`;
+        summary.appendChild(chip);
+      });
+      this.feedbackContent.appendChild(summary);
     }
+
+    this.feedbackEvents.slice().reverse().forEach(event => {
+      const item = document.createElement('div');
+      item.className = `feedback-item type-${event.type}`;
+      item.innerHTML = `
+        <div class="feedback-item-time">${event.positionLabel || this.formatTime(event.elapsedSec)}</div>
+        <div class="feedback-item-text"></div>
+        <div class="feedback-item-excerpt"></div>
+      `;
+      item.querySelector('.feedback-item-text').textContent = event.text;
+      item.querySelector('.feedback-item-excerpt').textContent = event.excerpt ? `原句：${event.excerpt}` : '';
+      item.addEventListener('click', () => this.focusSentence(event.sentenceIndex));
+      this.feedbackContent.appendChild(item);
+    });
+  }
+
+  formatTime(totalSeconds = 0) {
+    const minutes = Math.floor(totalSeconds / 60).toString().padStart(2, '0');
+    const seconds = Math.floor(totalSeconds % 60).toString().padStart(2, '0');
+    return `${minutes}:${seconds}`;
+  }
+
+  focusSentence(sentenceIndex) {
+    const target = this.subtitleContainer.querySelector(`[data-sentence-index="${sentenceIndex}"]`);
+    if (!target) return;
+    this.subtitleContainer.querySelectorAll('.feedback-target').forEach(item => item.classList.remove('feedback-target'));
+    target.classList.add('feedback-target');
+    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    clearTimeout(this.feedbackHighlightTimer);
+    this.feedbackHighlightTimer = setTimeout(() => target.classList.remove('feedback-target'), 3500);
   }
 
   // ===== 报告 =====
@@ -312,18 +402,26 @@ class ExpressionTrainer {
 
     const result = await window.api.getFinalReport({
       fullText: this.fullText,
-      stats: this.stats
+      stats: { ...this.stats, density: this.calculateDensity() },
+      session: {
+        id: this.sessionId || `session-${Date.now()}`,
+        source: this.sessionSource,
+        topic: this.sentences[0]?.slice(0, 100) || '',
+        fillerWords: this.fillerWords,
+        hedgeWords: this.hedgeWords
+      }
     });
 
     if (result.success) {
       this.lastReport = result.report;
-      this.renderReport(result.report);
+      this.renderReport(result.report, result.memoryExtracted);
+      if (result.profile) this.renderTrainingProfile(result.profile);
     } else {
       this.reportBody.innerHTML = `<p style="color:#ff6b6b;">生成失败: ${result.error}</p>`;
     }
   }
 
-  renderReport(report) {
+  renderReport(report, memoryExtracted = false) {
     let html = report
       .replace(/^### (.+)$/gm, '<h3>$1</h3>')
       .replace(/^## (.+)$/gm, '<h2>$1</h2>')
@@ -337,7 +435,10 @@ class ExpressionTrainer {
       .replace(/\n/g, '<br>');
 
     this.reportBody.innerHTML = `
-      <div style="text-align:right;margin-bottom:12px;">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;gap:12px;">
+        <span style="font-size:11px;color:${memoryExtracted ? '#69db7c' : '#888'};">
+          ${memoryExtracted ? '🧠 已提炼并写入长期记忆' : '⚠️ 本次报告未能提炼为长期记忆'}
+        </span>
         <button id="btn-save-report" style="background:#E5007E;color:#fff;border:none;border-radius:6px;padding:8px 14px;font-size:12px;cursor:pointer;">💾 保存为 Markdown</button>
       </div>
       ${html}
@@ -378,10 +479,42 @@ class ExpressionTrainer {
     this.timer.textContent = `${minutes}:${seconds}`;
   }
 
+  getElapsedSeconds() {
+    if (!this.startTime) return this.stats.duration || 0;
+    let totalPaused = this.pausedTime;
+    if (this.pauseStart) totalPaused += Date.now() - this.pauseStart;
+    return Math.max(0, Math.floor((Date.now() - this.startTime - totalPaused) / 1000));
+  }
+
+  calculateDensity() {
+    if (!this.stats.totalWords) return 100;
+    return Math.round((this.stats.totalWords - this.stats.fillers - this.stats.hedges) / this.stats.totalWords * 100);
+  }
+
+  async loadTrainingMemory() {
+    try {
+      const memory = await window.api.getTrainingMemory();
+      this.renderTrainingProfile(memory.profile);
+    } catch (error) {
+      console.warn('训练记忆读取失败', error);
+    }
+  }
+
+  renderTrainingProfile(profile) {
+    if (!profile) return;
+    this.memorySessionCount.textContent = profile.totalSessions || 0;
+    this.memoryCurrentFocus.textContent = profile.currentFocus || '完成第一次训练，建立你的表达基线';
+  }
+
   resetStats() {
     this.stats = { fillers: 0, hedges: 0, vagueWords: 0, totalWords: 0, duration: 0 };
+    this.fillerWords = [];
+    this.hedgeWords = [];
+    this.lastFeedbackText = '';
     this.updateStatsDisplay();
     this.feedbackContent.innerHTML = '';
+    this.feedbackEvents = [];
+    this.feedbackEventId = 0;
   }
 
   showError(msg) {
@@ -434,6 +567,7 @@ class ExpressionTrainer {
     this.btnCopyText.classList.add('hidden');
     this.btnSaveText.classList.add('hidden');
     this.btnClear.classList.add('hidden');
+    this.feedbackHint.textContent = '说话时只记录，结束后点击反馈定位原句';
   }
 
   // ===== 粘贴逐字稿分析 =====
@@ -454,15 +588,19 @@ class ExpressionTrainer {
     // 把文本显示到字幕区（高亮标记）
     this.subtitleContainer.innerHTML = '';
     this.fullText = text;
+    this.sessionId = `paste-${Date.now()}`;
+    this.sessionSource = 'transcript';
+    this.startTime = null;
     this.resetStats();
 
     // 按句号/问号/感叹号/换行分句
     const sentences = text.split(/(?<=[。！？\n])/g).filter(s => s.trim());
     this.sentences = sentences;
 
-    for (const sentence of sentences) {
+    for (const [sentenceIndex, sentence] of sentences.entries()) {
       const line = document.createElement('div');
       line.className = 'subtitle-line';
+      line.dataset.sentenceIndex = sentenceIndex;
       line.innerHTML = this.highlightText(sentence.trim());
       this.subtitleContainer.appendChild(line);
 
@@ -473,6 +611,21 @@ class ExpressionTrainer {
         this.stats.hedges += analysis.hedges.length;
         this.stats.vagueWords += analysis.vagueWords.length;
         this.stats.totalWords += analysis.totalWords;
+        this.fillerWords.push(...analysis.fillers.map(item => item.word));
+        this.hedgeWords.push(...analysis.hedges.map(item => item.word));
+
+        const meta = { sentenceIndex, excerpt: sentence.trim(), positionLabel: `第 ${sentenceIndex + 1} 句` };
+        analysis.vagueWords.forEach(item => {
+          this.addFeedbackItem(`「${item.word}」→ ${item.alternatives.slice(0, 3).join(' / ')}`, 'vague', meta);
+        });
+        if (analysis.fillers.length >= 2) {
+          const words = [...new Set(analysis.fillers.map(item => item.word))].slice(0, 3);
+          this.addFeedbackItem(`填充词：${words.join('、')}——试试停顿`, 'filler', meta);
+        }
+        if (analysis.hedges.length >= 1) {
+          const words = [...new Set(analysis.hedges.map(item => item.word))].slice(0, 2);
+          this.addFeedbackItem(`「${words.join('」「')}」→ 直接说`, 'hedge', meta);
+        }
       }
     }
 
@@ -484,6 +637,7 @@ class ExpressionTrainer {
     this.btnCopyText.classList.remove('hidden');
     this.btnSaveText.classList.remove('hidden');
     this.btnClear.classList.remove('hidden');
+    this.feedbackHint.textContent = '点击任意反馈，自动定位并高亮对应原句';
 
     // 请求AI语境化反馈
     this.requestRealtimeFeedback();

--- a/src/index.html
+++ b/src/index.html
@@ -31,6 +31,12 @@
         <span class="stat-label">表达密度</span>
         <span id="stat-density" class="stat-value stat-green">--</span>
       </div>
+      <div class="memory-card">
+        <div class="memory-title">🧠 长期训练记忆</div>
+        <div class="memory-count">已记录 <span id="memory-session-count">0</span> 次训练</div>
+        <div class="memory-label">当前重点</div>
+        <div id="memory-current-focus" class="memory-focus">完成第一次训练，建立你的表达基线</div>
+      </div>
     </aside>
 
     <!-- 中间：主内容区 -->
@@ -91,7 +97,8 @@
 
     <!-- 右栏：实时反馈 -->
     <aside class="panel-right">
-      <div class="panel-title">💡 实时反馈</div>
+      <div class="panel-title">💡 反馈时间线</div>
+      <div id="feedback-hint" class="feedback-hint">说话时只记录，结束后点击反馈定位原句</div>
       <div id="feedback-content" class="feedback-content">
         <!-- 实时反馈内容 -->
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -117,6 +117,19 @@ button, input, select, .subtitle-scroll, .feedback-content, .modal-body {
 .stat-yellow { color: #ffd43b; }
 .stat-green { color: #69db7c; }
 
+.memory-card {
+  margin-top: 22px;
+  padding: 12px;
+  border: 1px solid #292929;
+  border-radius: 10px;
+  background: #0b0b0b;
+}
+.memory-title { color: #aaa; font-size: 12px; margin-bottom: 8px; }
+.memory-count { color: #555; font-size: 11px; margin-bottom: 12px; }
+.memory-count span { color: #E5007E; font-family: "SF Mono", monospace; }
+.memory-label { color: #555; font-size: 10px; margin-bottom: 5px; }
+.memory-focus { color: #ddd; font-size: 12px; line-height: 1.55; }
+
 /* 实时反馈 */
 .feedback-content {
   flex: 1;
@@ -125,11 +138,39 @@ button, input, select, .subtitle-scroll, .feedback-content, .modal-body {
   line-height: 1.6;
   color: #ccc;
 }
+.feedback-hint {
+  margin: -7px 0 12px;
+  color: #555;
+  font-size: 10px;
+  line-height: 1.5;
+}
+.feedback-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 0 0 10px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid #222;
+}
+.feedback-summary-chip {
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: #181818;
+  color: #999;
+  font-size: 10px;
+}
 .feedback-item {
-  padding: 8px 0;
+  padding: 9px 7px;
   border-bottom: 1px solid #1a1a1a;
   color: #ddd;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s;
 }
+.feedback-item:hover { background: #181818; }
+.feedback-item-time { color: #555; font-size: 10px; font-family: "SF Mono", monospace; margin-bottom: 3px; }
+.feedback-item-text { font-size: 13px; line-height: 1.45; }
+.feedback-item-excerpt { color: #666; font-size: 10px; line-height: 1.45; margin-top: 4px; }
 .feedback-item:last-child { border-bottom: none; }
 .feedback-item.type-vague { color: #ffd43b; }
 .feedback-item.type-filler { color: #888; font-size: 12px; }
@@ -192,6 +233,13 @@ button, input, select, .subtitle-scroll, .feedback-content, .modal-body {
 .subtitle-line.old { color: #666; font-size: 22px; }
 .subtitle-line.hint { color: #444; font-size: 20px; }
 .subtitle-line.interim-line { color: #aaa; }
+.subtitle-line.feedback-target {
+  color: #fff;
+  background: rgba(229, 0, 126, 0.13);
+  box-shadow: 0 0 0 8px rgba(229, 0, 126, 0.13);
+  border-radius: 4px;
+  transition: background 0.25s, box-shadow 0.25s;
+}
 
 /* 高亮 */
 .subtitle-line .filler { color: #ff6b6b; text-decoration: underline wavy; }


### PR DESCRIPTION
## What changed

- add local short-term session memory and an aggregated long-term coaching profile
- extract reports into structured problems, evidence, strengths, confidence, and recommended drills
- promote an observed issue to a stable pattern only after it appears across multiple sessions
- add a feedback timeline that binds each suggestion to a timestamp or sentence and highlights the matching transcript
- pass real session context and historical coaching focus into realtime and final-report prompts

## Why

Realtime feedback was difficult to consume while speaking and was not anchored to the sentence that triggered it. Reports were also mostly isolated outputs, so repeated coaching patterns could not influence future sessions.

## User impact

Users can finish speaking first, then click feedback to locate the exact source sentence. Report findings now contribute to a local, explainable training profile and the next coaching focus.

## Validation

- Node syntax checks for the main process, prompts, memory module, and renderer
- structured-memory JSON parsing and normalization test
- multi-session stable-pattern aggregation test
- long-text lexicon and prompt-anchor test
- Electron startup smoke test
- packaged macOS app signature and bundled ASR model verification
