### PR TITLE
fix: 修复原文复制和保存按钮状态更新报错

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -397,8 +397,8 @@ class ExpressionTrainer {
   copyOriginalText() {
     if (!this.fullText.trim()) return;
     navigator.clipboard.writeText(this.fullText).then(() => {
-      this.btnCopyText.querySelector('.btn-label').textContent = '✓ 已复制';
-      setTimeout(() => { this.btnCopyText.querySelector('.btn-label').textContent = '复制原文'; }, 1500);
+      this.btnCopyText.textContent = '✓ 已复制';
+      setTimeout(() => { this.btnCopyText.textContent = '📋 复制'; }, 1500);
     });
   }
 
@@ -413,8 +413,8 @@ class ExpressionTrainer {
     try {
       const result = await window.api.saveFile(markdown, filename);
       if (result.success) {
-        this.btnSaveText.querySelector('.btn-label').textContent = '✓ 已保存';
-        setTimeout(() => { this.btnSaveText.querySelector('.btn-label').textContent = '保存原文'; }, 2000);
+        this.btnSaveText.textContent = '✓ 已保存';
+        setTimeout(() => { this.btnSaveText.textContent = '💾 保存'; }, 2000);
       }
     } catch (e) {
       alert('保存失败: ' + e.message);


### PR DESCRIPTION
## 问题

“复制原文”和“保存原文”按钮直接包含文本，没有 `.btn-label` 子元素。操作成功后，现有代码仍会查询该元素并更新 `textContent`，因此会访问 `null`：

- 复制成功后，按钮状态提示无法正常更新，并产生未处理异常
- 保存接口返回成功后，按钮更新异常还会被误报为“保存失败”

## 修改

- 直接更新两个按钮自身的 `textContent`，与当前 DOM 结构保持一致
- 成功提示结束后恢复原有的 `📋 复制` 和 `💾 保存` 文案

本次不改变剪贴板写入、文件保存或其他业务流程。

## 验证

- [x] `node --check src/app.js`
- [x] `git diff --check`
- [x] 浏览器 smoke test（mock 剪贴板与 `window.api.saveFile` 的成功响应）：复制、保存按钮会分别显示“✓ 已复制”“✓ 已保存”，并在设定时间后恢复原文案；过程中没有页面脚本异常或保存失败误报
