### PR TITLE
fix: migrate DeepSeek defaults to V4

### DIFF
--- a/lib/ai-feedback.js
+++ b/lib/ai-feedback.js
@@ -10,6 +10,11 @@ const PROVIDER_ENDPOINTS = {
   openai: 'https://api.openai.com/v1/chat/completions',
   deepseek: 'https://api.deepseek.com/v1/chat/completions'
 };
+const {
+  DEFAULT_DEEPSEEK_MODEL,
+  normalizeDeepSeekSettings,
+  getDeepSeekRequestBody
+} = require('./deepseek-config');
 
 /**
  * 发送请求到 OpenAI 兼容接口
@@ -25,7 +30,8 @@ async function callAPI(endpoint, apiKey, model, messages, maxTokens = 200) {
       model,
       messages,
       max_tokens: maxTokens,
-      temperature: 0.7
+      temperature: 0.7,
+      ...(endpoint === PROVIDER_ENDPOINTS.deepseek ? getDeepSeekRequestBody(model) : {})
     })
   });
 
@@ -42,6 +48,7 @@ async function callAPI(endpoint, apiKey, model, messages, maxTokens = 200) {
  * 获取endpoint和配置
  */
 function getProviderConfig(settings) {
+  settings = normalizeDeepSeekSettings(settings);
   const { provider, apiKey, model, ollamaUrl, customEndpoint, customModel } = settings;
 
   switch (provider) {
@@ -49,19 +56,13 @@ function getProviderConfig(settings) {
       return {
         endpoint: PROVIDER_ENDPOINTS.deepseek,
         apiKey,
-        model: model || 'deepseek-chat'
+        model: model || DEFAULT_DEEPSEEK_MODEL
       };
     case 'openai':
       return {
         endpoint: PROVIDER_ENDPOINTS.openai,
         apiKey,
         model: model || 'gpt-4o-mini'
-      };
-    case 'deepseek':
-      return {
-        endpoint: PROVIDER_ENDPOINTS.deepseek,
-        apiKey,
-        model: model || 'deepseek-chat'
       };
     case 'ollama':
       return {

--- a/lib/deepseek-config.js
+++ b/lib/deepseek-config.js
@@ -1,0 +1,47 @@
+const DEFAULT_DEEPSEEK_MODEL = 'deepseek-v4-flash';
+
+// These are the legacy model values previously written by this application.
+const LEGACY_APP_MODELS = new Set([
+  'deepseek-chat',
+  'deepseek-coder'
+]);
+
+const V4_MODELS = new Set([
+  'deepseek-v4-flash',
+  'deepseek-v4-pro'
+]);
+
+/**
+ * Keep existing app-generated DeepSeek settings compatible with the current
+ * model identifiers. Unknown values are not changed by this migration.
+ */
+function normalizeDeepSeekSettings(settings) {
+  if (!settings || typeof settings !== 'object' || settings.provider !== 'deepseek') {
+    return settings;
+  }
+
+  if (settings.model && !LEGACY_APP_MODELS.has(settings.model)) {
+    return settings;
+  }
+
+  return {
+    ...settings,
+    model: DEFAULT_DEEPSEEK_MODEL
+  };
+}
+
+/**
+ * The app historically used deepseek-chat, which maps to non-thinking mode.
+ * Preserve that low-latency behavior when using the new V4 model names.
+ */
+function getDeepSeekRequestBody(model) {
+  return V4_MODELS.has(model)
+    ? { thinking: { type: 'disabled' } }
+    : {};
+}
+
+module.exports = {
+  DEFAULT_DEEPSEEK_MODEL,
+  normalizeDeepSeekSettings,
+  getDeepSeekRequestBody
+};

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, ipcMain, session } = require('electron');
 const path = require('path');
 const fs = require('fs');
+const { DEFAULT_DEEPSEEK_MODEL, normalizeDeepSeekSettings } = require('./lib/deepseek-config');
 const { initASR, feedAudio, stopRecognition } = require('./lib/asr');
 const { loadLexicon, analyzeText } = require('./lib/lexicon');
 const { sendFeedback, sendReport } = require('./lib/ai-feedback');
@@ -35,12 +36,13 @@ function getSettingsPath() {
 function loadSettings() {
   const settingsPath = getSettingsPath();
   if (fs.existsSync(settingsPath)) {
-    return JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    return normalizeDeepSeekSettings(settings);
   }
   return {
     provider: 'deepseek',
     apiKey: '',
-    model: 'deepseek-chat',
+    model: DEFAULT_DEEPSEEK_MODEL,
     ollamaUrl: 'http://localhost:11434',
     customEndpoint: '',
     customModel: ''

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "dev": "electron . --dev"
+    "dev": "electron . --dev",
+    "test": "node --test"
   },
   "keywords": ["expression", "training", "speech", "asr", "chinese"],
   "author": "sisi",

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,7 +1,7 @@
 {
   "provider": "deepseek",
   "apiKey": "your-api-key-here",
-  "model": "deepseek-chat",
+  "model": "deepseek-v4-flash",
   "ollamaUrl": "http://localhost:11434",
   "customEndpoint": "",
   "customModel": ""

--- a/src/settings.js
+++ b/src/settings.js
@@ -14,8 +14,8 @@ const PROVIDER_CONFIG = {
     needsKey: true,
     keyHint: '在 platform.deepseek.com 获取',
     models: [
-      { value: 'deepseek-chat', label: 'DeepSeek Chat（推荐）' },
-      { value: 'deepseek-coder', label: 'DeepSeek Coder' }
+      { value: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash（推荐）' },
+      { value: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro' }
     ]
   },
   ollama: {
@@ -73,6 +73,16 @@ class SettingsPage {
 
     // 设置模型（在onProviderChange填充选项后）
     if (settings.model) {
+      const modelExists = Array.from(this.modelSelect.options)
+        .some(option => option.value === settings.model);
+
+      if (!modelExists && this.providerSelect.value === 'deepseek') {
+        const opt = document.createElement('option');
+        opt.value = settings.model;
+        opt.textContent = `${settings.model}（现有自定义值）`;
+        this.modelSelect.appendChild(opt);
+      }
+
       this.modelSelect.value = settings.model;
     }
   }

--- a/test/deepseek-v4.test.js
+++ b/test/deepseek-v4.test.js
@@ -1,0 +1,125 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DEFAULT_DEEPSEEK_MODEL,
+  normalizeDeepSeekSettings,
+  getDeepSeekRequestBody
+} = require('../lib/deepseek-config');
+const { sendFeedback, sendReport } = require('../lib/ai-feedback');
+
+function captureRequests(t) {
+  const originalFetch = global.fetch;
+  const requests = [];
+
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+
+  global.fetch = async (endpoint, options) => {
+    requests.push({ endpoint, options, body: JSON.parse(options.body) });
+    return {
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: '测试反馈' } }] })
+    };
+  };
+
+  return requests;
+}
+
+test('migrates model values previously written by the app', () => {
+  assert.equal(
+    normalizeDeepSeekSettings({ provider: 'deepseek' }).model,
+    DEFAULT_DEEPSEEK_MODEL
+  );
+
+  for (const model of ['', 'deepseek-chat', 'deepseek-coder']) {
+    const original = { provider: 'deepseek', model };
+    const migrated = normalizeDeepSeekSettings(original);
+    assert.equal(migrated.model, DEFAULT_DEEPSEEK_MODEL);
+    assert.equal(original.model, model);
+  }
+});
+
+test('preserves current and manually configured model values', () => {
+  for (const model of ['deepseek-v4-flash', 'deepseek-v4-pro', 'custom-model']) {
+    const original = { provider: 'deepseek', model };
+    const snapshot = { ...original };
+    assert.deepEqual(normalizeDeepSeekSettings(original), snapshot);
+    assert.deepEqual(original, snapshot);
+  }
+
+  const openAI = { provider: 'openai' };
+  assert.deepEqual(normalizeDeepSeekSettings(openAI), { provider: 'openai' });
+  assert.equal('model' in openAI, false);
+});
+
+test('uses non-thinking mode for current V4 models only', () => {
+  const nonThinking = { thinking: { type: 'disabled' } };
+  assert.deepEqual(getDeepSeekRequestBody('deepseek-v4-flash'), nonThinking);
+  assert.deepEqual(getDeepSeekRequestBody('deepseek-v4-pro'), nonThinking);
+  assert.deepEqual(getDeepSeekRequestBody('custom-model'), {});
+});
+
+test('sends legacy DeepSeek settings as V4 non-thinking requests', async (t) => {
+  const requests = captureRequests(t);
+
+  const result = await sendFeedback('这是一段测试文本', {
+    provider: 'deepseek',
+    apiKey: 'test-key',
+    model: 'deepseek-chat'
+  });
+
+  const request = requests[0];
+  const body = request.body;
+  assert.equal(result, '测试反馈');
+  assert.equal(request.endpoint, 'https://api.deepseek.com/v1/chat/completions');
+  assert.equal(body.model, 'deepseek-v4-flash');
+  assert.deepEqual(body.thinking, { type: 'disabled' });
+  assert.equal(body.temperature, 0.7);
+  assert.equal(body.max_tokens, 150);
+});
+
+test('uses V4 non-thinking mode for final reports', async (t) => {
+  const requests = captureRequests(t);
+
+  await sendReport('这是完整转写', {
+    duration: 60,
+    totalWords: 20,
+    fillers: 1,
+    hedges: 1,
+    vagueWords: 1
+  }, {
+    provider: 'deepseek',
+    apiKey: 'test-key',
+    model: 'deepseek-v4-pro'
+  });
+
+  assert.equal(requests[0].body.model, 'deepseek-v4-pro');
+  assert.deepEqual(requests[0].body.thinking, { type: 'disabled' });
+  assert.equal(requests[0].body.max_tokens, 8192);
+});
+
+test('does not add thinking controls to non-DeepSeek endpoints or unknown models', async (t) => {
+  const requests = captureRequests(t);
+  const settingsCases = [
+    { provider: 'openai', apiKey: 'test-key', model: 'gpt-4o-mini' },
+    { provider: 'ollama', ollamaUrl: 'http://localhost:11434', model: 'qwen2.5:7b' },
+    {
+      provider: 'custom',
+      apiKey: 'test-key',
+      customEndpoint: 'https://example.com/v1/chat/completions',
+      customModel: 'custom-model'
+    },
+    { provider: 'deepseek', apiKey: 'test-key', model: 'future-deepseek-model' }
+  ];
+
+  for (const settings of settingsCases) {
+    await sendFeedback('这是一段测试文本', settings);
+  }
+
+  assert.equal(requests.length, settingsCases.length);
+  requests.forEach(request => {
+    assert.equal('thinking' in request.body, false);
+  });
+});


### PR DESCRIPTION
## 背景

DeepSeek 官方将于北京时间 2026-07-24 23:59 停用 `deepseek-chat` 和 `deepseek-reasoner` 旧模型名，当前 ChatCompletions 模型已切换为 `deepseek-v4-flash` 和 `deepseek-v4-pro`。

项目目前默认使用 `deepseek-chat`，设置页还会保存现行模型列表中已不再提供的 `deepseek-coder`。在旧名称停用后，默认 AI 反馈链路可能直接失效。

## 改动

- 将新安装、设置页和示例配置的默认模型更新为 `deepseek-v4-flash`
- 在加载设置时兼容项目曾经写入的 `deepseek-chat` / `deepseek-coder` / 空模型值
- 未知或手工配置的模型值保持不变，设置页打开后也不会将其静默清空
- 向官方 DeepSeek endpoint 的 V4 请求显式发送 `thinking: { type: "disabled" }`
- 移除重复且不可达的 `deepseek` provider 分支
- 使用 Node.js 内置的 `node:test` 增加设置迁移和请求体回归测试，不增加依赖

## 兼容策略

`deepseek-chat` 当前对应 V4 Flash 的非思考模式，而 V4 新模型默认启用思考模式。如果只替换模型名，会改变实时反馈的延迟和请求语义，并使现有 `temperature` 参数失效。因此本 PR 显式保持非思考行为。

- 迁移只在读取和请求时生效，不会主动改写用户的 `settings.json`
- 项目设置页从未提供 `deepseek-reasoner`；为避免将手工配置的思考模式静默改成非思考，本 PR 不自动改写该未知值
- DeepSeek API endpoint 和 API Key 配置保持不变
- 普通 OpenAI、Ollama 和非 DeepSeek 自定义 endpoint 不会收到 `thinking` 参数

## 验证

- `npm test` — 6/6 通过
- `node --check` — 所有改动的 JavaScript 文件通过
- `git diff --check` — 通过
- 测试全程 mock `fetch`，未调用真实 API，也不需要 API Key

## 官方依据

- [DeepSeek V4 更新及旧模型名停用时间](https://api-docs.deepseek.com/zh-cn/updates/)
- [DeepSeek 思考模式开关语义](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode/)
- [DeepSeek 当前模型列表](https://api-docs.deepseek.com/zh-cn/api/list-models/)
