### PR TITLE
调整LLM大模型配置功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ models/*.onnx
 models/sherpa-onnx-*/
 dist/
 .DS_Store
+.idea/
 
 demo-*.html
 prompt-playground.html

--- a/lib/ai-feedback.js
+++ b/lib/ai-feedback.js
@@ -42,15 +42,9 @@ async function callAPI(endpoint, apiKey, model, messages, maxTokens = 200) {
  * 获取endpoint和配置
  */
 function getProviderConfig(settings) {
-  const { provider, apiKey, model, ollamaUrl, customEndpoint, customModel } = settings;
+  const { provider, apiKey, model, ollamaUrl, baseUrl, customModel } = settings;
 
   switch (provider) {
-    case 'deepseek':
-      return {
-        endpoint: PROVIDER_ENDPOINTS.deepseek,
-        apiKey,
-        model: model || 'deepseek-chat'
-      };
     case 'openai':
       return {
         endpoint: PROVIDER_ENDPOINTS.openai,
@@ -70,10 +64,13 @@ function getProviderConfig(settings) {
         model: model || 'qwen2.5:7b'
       };
     case 'custom':
+      // 用户输入 BASE URL，自动追加 /chat/completions
+      const base = (baseUrl || '').replace(/\/+$/, '');
+      const endpoint = base ? `${base}/chat/completions` : '';
       return {
-        endpoint: customEndpoint,
-        apiKey,
-        model: customModel || model
+        endpoint,
+        apiKey: apiKey || '',
+        model: customModel || model || ''
       };
     default:
       throw new Error(`未知的 provider: ${provider}`);
@@ -133,4 +130,44 @@ function formatFeedback(text) {
   return html;
 }
 
-module.exports = { sendFeedback, sendReport };
+/**
+ * 测试 LLM 连通性
+ * 发送一条极简请求验证配置是否可用
+ */
+async function testConnection(settings) {
+  const config = getProviderConfig(settings);
+  if (!config.endpoint) {
+    return { success: false, error: '端点地址未配置' };
+  }
+
+  const messages = [
+    { role: 'user', content: 'OK' }
+  ];
+
+  try {
+    const response = await fetch(config.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${config.apiKey}`
+      },
+      body: JSON.stringify({
+        model: config.model,
+        messages,
+        max_tokens: 2,
+        temperature: 0
+      })
+    });
+
+    if (!response.ok) {
+      const error = await response.text().catch(() => '未知错误');
+      return { success: false, error: `API 请求失败 (${response.status}): ${error}` };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: `连接失败: ${error.message}` };
+  }
+}
+
+module.exports = { sendFeedback, sendReport, testConnection };

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const { initASR, feedAudio, stopRecognition } = require('./lib/asr');
 const { loadLexicon, analyzeText } = require('./lib/lexicon');
-const { sendFeedback, sendReport } = require('./lib/ai-feedback');
+const { sendFeedback, sendReport, testConnection } = require('./lib/ai-feedback');
 
 let mainWindow;
 let settingsWindow;
@@ -27,6 +27,14 @@ function saveCustomPrompt(data) {
   fs.writeFileSync(getCustomPromptPath(), JSON.stringify(data, null, 2));
 }
 
+// 各 Provider 的默认配置
+const DEFAULT_PROVIDER_CONFIGS = {
+  openai: { apiKey: '', model: 'gpt-4o-mini' },
+  deepseek: { apiKey: '', model: 'deepseek-chat' },
+  ollama: { ollamaUrl: 'http://localhost:11434', model: 'qwen2.5:7b' },
+  custom: { apiKey: '', baseUrl: '', model: '' }
+};
+
 // 设置文件路径
 function getSettingsPath() {
   return path.join(app.getPath('userData'), 'settings.json');
@@ -35,21 +43,53 @@ function getSettingsPath() {
 function loadSettings() {
   const settingsPath = getSettingsPath();
   if (fs.existsSync(settingsPath)) {
-    return JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    const raw = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    // 兼容旧版扁平结构 → 迁移到 per-provider 结构
+    if (!raw.providers) {
+      const migrated = {
+        provider: raw.provider || 'deepseek',
+        providers: {
+          openai: { ...DEFAULT_PROVIDER_CONFIGS.openai },
+          deepseek: { ...DEFAULT_PROVIDER_CONFIGS.deepseek },
+          ollama: { ...DEFAULT_PROVIDER_CONFIGS.ollama },
+          custom: { ...DEFAULT_PROVIDER_CONFIGS.custom }
+        }
+      };
+      // 将旧字段迁移到对应 provider
+      const p = migrated.provider;
+      if (raw.apiKey) migrated.providers[p].apiKey = raw.apiKey;
+      if (raw.model) migrated.providers[p].model = raw.model;
+      if (raw.ollamaUrl) migrated.providers.ollama.ollamaUrl = raw.ollamaUrl;
+      if (raw.customEndpoint) migrated.providers.custom.baseUrl = raw.customEndpoint;
+      if (raw.customModel) migrated.providers.custom.model = raw.customModel;
+      saveSettings(migrated);
+      return migrated;
+    }
+    // 确保每个 provider 都有完整的默认字段
+    for (const key of Object.keys(DEFAULT_PROVIDER_CONFIGS)) {
+      if (!raw.providers[key]) {
+        raw.providers[key] = { ...DEFAULT_PROVIDER_CONFIGS[key] };
+      } else {
+        raw.providers[key] = { ...DEFAULT_PROVIDER_CONFIGS[key], ...raw.providers[key] };
+      }
+    }
+    return raw;
   }
   return {
     provider: 'deepseek',
-    apiKey: '',
-    model: 'deepseek-chat',
-    ollamaUrl: 'http://localhost:11434',
-    customEndpoint: '',
-    customModel: ''
+    providers: JSON.parse(JSON.stringify(DEFAULT_PROVIDER_CONFIGS))
   };
 }
 
 function saveSettings(settings) {
   const settingsPath = getSettingsPath();
   fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+}
+
+/** 获取当前选中 provider 的配置 */
+function getCurrentProviderSettings(settings) {
+  const config = settings.providers[settings.provider];
+  return config || DEFAULT_PROVIDER_CONFIGS[settings.provider] || {};
 }
 
 function createMainWindow() {
@@ -208,6 +248,12 @@ ipcMain.handle('stop-asr', () => {
   return { success: true, finalText };
 });
 
+// LLM 连通性测试
+ipcMain.handle('test-llm-connection', async (event, settings) => {
+  const providerConfig = getCurrentProviderSettings(settings);
+  return await testConnection({ ...settings, ...providerConfig });
+});
+
 // 词库分析
 ipcMain.handle('analyze-text', (event, text) => {
   return analyzeText(text);
@@ -232,9 +278,10 @@ ipcMain.handle('save-file', async (event, content, filename) => {
 // AI反馈（传入customPrompt）
 ipcMain.handle('get-realtime-feedback', async (event, text) => {
   const settings = loadSettings();
+  const providerConfig = getCurrentProviderSettings(settings);
   const customPrompt = loadCustomPrompt();
   try {
-    const feedback = await sendFeedback(text, settings, customPrompt);
+    const feedback = await sendFeedback(text, { ...settings, ...providerConfig }, customPrompt);
     return { success: true, feedback };
   } catch (error) {
     return { success: false, error: error.message };
@@ -243,9 +290,10 @@ ipcMain.handle('get-realtime-feedback', async (event, text) => {
 
 ipcMain.handle('get-final-report', async (event, { fullText, stats }) => {
   const settings = loadSettings();
+  const providerConfig = getCurrentProviderSettings(settings);
   const customPrompt = loadCustomPrompt();
   try {
-    const report = await sendReport(fullText, stats, settings, customPrompt);
+    const report = await sendReport(fullText, stats, { ...settings, ...providerConfig }, customPrompt);
     return { success: true, report };
   } catch (error) {
     return { success: false, error: error.message };

--- a/preload.js
+++ b/preload.js
@@ -29,6 +29,7 @@ contextBridge.exposeInMainWorld('api', {
   // AI反馈
   getRealtimeFeedback: (text) => ipcRenderer.invoke('get-realtime-feedback', text),
   getFinalReport: (data) => ipcRenderer.invoke('get-final-report', data),
+  testLLMConnection: (settings) => ipcRenderer.invoke('test-llm-connection', settings),
 
   // 文件保存
   saveFile: (content, filename) => ipcRenderer.invoke('save-file', content, filename),

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,8 +1,22 @@
 {
   "provider": "deepseek",
-  "apiKey": "your-api-key-here",
-  "model": "deepseek-chat",
-  "ollamaUrl": "http://localhost:11434",
-  "customEndpoint": "",
-  "customModel": ""
+  "providers": {
+    "openai": {
+      "apiKey": "",
+      "model": "gpt-4o-mini"
+    },
+    "deepseek": {
+      "apiKey": "your-api-key-here",
+      "model": "deepseek-chat"
+    },
+    "ollama": {
+      "ollamaUrl": "http://localhost:11434",
+      "model": "qwen2.5:7b"
+    },
+    "custom": {
+      "apiKey": "",
+      "baseUrl": "https://api.example.com/v1",
+      "model": ""
+    }
+  }
 }

--- a/src/settings.html
+++ b/src/settings.html
@@ -92,11 +92,19 @@
       background: #339af0;
     }
 
+    .message-container {
+      position: relative;
+      height: 20px;
+      margin-top: 12px;
+    }
+
     .save-success {
+      position: absolute;
+      left: 0;
+      right: 0;
       text-align: center;
       color: #69db7c;
       font-size: 13px;
-      margin-top: 12px;
       opacity: 0;
       transition: opacity 0.3s;
     }
@@ -105,10 +113,31 @@
       opacity: 1;
     }
 
+    .connection-error {
+      position: absolute;
+      left: 0;
+      right: 0;
+      text-align: center;
+      color: #ff6b6b;
+      font-size: 13px;
+      opacity: 0;
+      transition: opacity 0.3s;
+      word-break: break-all;
+    }
+
+    .connection-error.show {
+      opacity: 1;
+    }
+
     .model-presets {
       font-size: 12px;
       color: #666;
       margin-top: 4px;
+    }
+
+    .btn-save.loading {
+      opacity: 0.6;
+      pointer-events: none;
     }
   </style>
 </head>
@@ -146,8 +175,9 @@
     </div>
 
     <div class="form-group conditional" id="group-custom">
-      <label>自定义 Endpoint</label>
-      <input type="text" id="custom-endpoint" placeholder="https://api.example.com/v1">
+      <label>OPENAI 协议 BASE URL</label>
+      <input type="text" id="custom-base-url" placeholder="https://api.example.com/v1">
+      <div class="hint">请求时会自动追加 /chat/completions</div>
     </div>
 
     <div class="form-group conditional" id="group-custom-model">
@@ -155,8 +185,11 @@
       <input type="text" id="custom-model" placeholder="model-name">
     </div>
 
+    <div class="message-container">
+      <div class="save-success" id="save-success">✓ 已保存</div>
+      <div class="connection-error" id="connection-error"></div>
+    </div>
     <button class="btn-save" id="btn-save">保存设置</button>
-    <div class="save-success" id="save-success">✓ 已保存</div>
   </div>
 
   <script src="settings.js"></script>

--- a/src/settings.js
+++ b/src/settings.js
@@ -41,7 +41,7 @@ class SettingsPage {
     this.modelSelect = document.getElementById('model');
     this.modelHint = document.getElementById('model-hint');
     this.ollamaUrlInput = document.getElementById('ollama-url');
-    this.customEndpointInput = document.getElementById('custom-endpoint');
+    this.customBaseUrlInput = document.getElementById('custom-base-url');
     this.customModelInput = document.getElementById('custom-model');
     this.btnSave = document.getElementById('btn-save');
     this.saveSuccess = document.getElementById('save-success');
@@ -61,19 +61,26 @@ class SettingsPage {
   }
 
   async loadSettings() {
-    const settings = await window.api.getSettings();
+    this.settings = await window.api.getSettings();
 
-    this.providerSelect.value = settings.provider || 'deepseek';
-    this.apikeyInput.value = settings.apiKey || '';
-    this.ollamaUrlInput.value = settings.ollamaUrl || 'http://localhost:11434';
-    this.customEndpointInput.value = settings.customEndpoint || '';
-    this.customModelInput.value = settings.customModel || '';
+    this.providerSelect.value = this.settings.provider || 'deepseek';
 
+    // 先填充模型列表再加载字段值
     this.onProviderChange();
+  }
 
-    // 设置模型（在onProviderChange填充选项后）
-    if (settings.model) {
-      this.modelSelect.value = settings.model;
+  /** 加载指定 provider 的配置到表单字段 */
+  loadProviderFields(provider) {
+    const providerConfig = this.settings?.providers?.[provider] || {};
+
+    this.apikeyInput.value = providerConfig.apiKey || '';
+    this.ollamaUrlInput.value = providerConfig.ollamaUrl || 'http://localhost:11434';
+    this.customBaseUrlInput.value = providerConfig.baseUrl || '';
+    this.customModelInput.value = providerConfig.customModel || '';
+
+    // 设置模型下拉框（非 custom 模式）
+    if (providerConfig.model && provider !== 'custom') {
+      this.modelSelect.value = providerConfig.model;
     }
   }
 
@@ -105,25 +112,72 @@ class SettingsPage {
     } else {
       this.modelSelect.parentElement.style.display = 'none';
     }
+
+    // 切换后加载该 provider 保存的配置到表单字段
+    this.loadProviderFields(provider);
   }
 
   async save() {
-    const settings = {
-      provider: this.providerSelect.value,
-      apiKey: this.apikeyInput.value.trim(),
-      model: this.modelSelect.value,
-      ollamaUrl: this.ollamaUrlInput.value.trim(),
-      customEndpoint: this.customEndpointInput.value.trim(),
-      customModel: this.customModelInput.value.trim()
-    };
+    const provider = this.providerSelect.value;
+
+    // 隐藏上次的错误提示
+    const errorEl = document.getElementById('connection-error');
+    errorEl.classList.remove('show');
+    errorEl.textContent = '';
+
+    // 先获取完整 settings（包含所有 provider 的独立配置）
+    const settings = await window.api.getSettings();
+
+    // 只更新当前 provider 的配置
+    settings.provider = provider;
+    if (!settings.providers) {
+      settings.providers = {};
+    }
+
+    if (provider === 'custom') {
+      // custom 的模型名来自自定义输入框
+      settings.providers[provider] = {
+        apiKey: this.apikeyInput.value.trim(),
+        model: this.customModelInput.value.trim(),
+        ollamaUrl: this.ollamaUrlInput.value.trim(),
+        baseUrl: this.customBaseUrlInput.value.trim(),
+        customModel: this.customModelInput.value.trim()
+      };
+    } else {
+      settings.providers[provider] = {
+        apiKey: this.apikeyInput.value.trim(),
+        model: this.modelSelect.value,
+        ollamaUrl: this.ollamaUrlInput.value.trim(),
+        baseUrl: this.customBaseUrlInput.value.trim(),
+        customModel: ''
+      };
+    }
 
     await window.api.saveSettings(settings);
 
-    // 显示保存成功，然后自动关闭窗口
-    this.saveSuccess.classList.add('show');
-    setTimeout(() => {
-      window.close();
-    }, 800);
+    // 更新缓存，让下次切换 provider 时能看到最新值
+    this.settings = settings;
+
+    // 测试连通性
+    this.btnSave.textContent = '⏳ 测试连接中...';
+    this.btnSave.classList.add('loading');
+    const result = await window.api.testLLMConnection(settings);
+
+    if (result.success) {
+      // 连接成功 → 显示保存成功并关闭
+      this.btnSave.textContent = '保存设置';
+      this.btnSave.classList.remove('loading');
+      this.saveSuccess.classList.add('show');
+      setTimeout(() => {
+        window.close();
+      }, 800);
+    } else {
+      // 连接失败 → 显示红色错误提示，不关闭
+      this.btnSave.textContent = '保存设置';
+      this.btnSave.classList.remove('loading');
+      errorEl.textContent = `⚠️ 大模型测试连接失败，请核对后重试!`;
+      errorEl.classList.add('show');
+    }
   }
 }
 


### PR DESCRIPTION
1.调整各个厂商的大模型配置分别保存配置信息，便于用户切换大模型
2.调整OpenAI协议大模型配置，更改为填写BaseURL，自动添加请求URL后缀路径
3.新增大模型配置测试连通性功能，确保配置信息正确后进行保存，若链接失败需用户进行核对后重试