### PR TITLE
fix: 替换默认的 'Electron' 应用名称和菜单栏

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,9 +1,12 @@
-const { app, BrowserWindow, ipcMain, session } = require('electron');
+const { app, BrowserWindow, ipcMain, session, Menu } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const { initASR, feedAudio, stopRecognition } = require('./lib/asr');
 const { loadLexicon, analyzeText } = require('./lib/lexicon');
 const { sendFeedback, sendReport, testConnection } = require('./lib/ai-feedback');
+
+// 覆盖应用显示名称（菜单栏、Dock、任务栏、窗口标题）
+app.setName('宇宙无敌表达训练');
 
 let mainWindow;
 let settingsWindow;
@@ -97,6 +100,7 @@ function createMainWindow() {
     width: 1200,
     height: 800,
     backgroundColor: '#000000',
+    title: '宇宙无敌表达训练',
     titleBarStyle: 'hiddenInset',
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -170,6 +174,36 @@ function createSettingsWindow() {
 
 // App lifecycle
 app.whenReady().then(() => {
+  // macOS 需要显式创建应用菜单，否则菜单栏显示默认的 "Electron"
+  // Windows/Linux 上此菜单同样适用，macOS 专属角色（hide/hideOthers）会自动生效
+  const appMenuTemplate = [
+    {
+      label: app.name,
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' }
+      ]
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' }
+      ]
+    }
+  ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(appMenuTemplate));
+
   // 加载词库
   loadLexicon();
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "expression-trainer",
+  "productName": "宇宙无敌表达训练",
   "version": "1.0.0",
   "description": "宇宙无敌表达训练系统 - 本地桌面版",
   "main": "main.js",


### PR DESCRIPTION
## 问题

开发模式下运行时，应用在 macOS Dock/菜单栏、Windows 任务栏中均显示为默认的 **Electron**，而非实际应用名称「宇宙无敌表达训练」，影响用户对应用的识别。

![Dock 显示 Electron](参考截图)

## 改动

所有改动**跨平台兼容**（macOS / Windows / Linux）：

### package.json
- 添加 `productName: "宇宙无敌表达训练"` — electron-builder 打包时使用此字段设置应用名称

### main.js
- 添加 `app.setName('宇宙无敌表达训练')` — 覆盖运行时显示名称（菜单栏、Dock、任务栏）
- 添加 `title: '宇宙无敌表达训练'` — 设置窗口标题
- 引入 `Menu` 并创建自定义应用菜单 — 替换默认的 "Electron" 菜单项
  - macOS 专属角色（`hide`/`hideOthers`/`unhide`）在其他平台自动生效或被忽略，无需平台判断
  - Edit 菜单使用 Electron 内置 role，跨平台通用

## 测试

- macOS ARM64: Dock 和菜单栏正确显示「宇宙无敌表达训练」，自定义菜单正常
- Windows/Linux: `app.setName` 和 `productName` 同样生效；macOS 专属菜单角色自动忽略

## 注意

此 PR 不包含 `start.sh`、图标文件或打包配置 — 这些是本地开发便利工具，不属于核心修复。