### PR TITLE
feat: 异步后台报告生成 + 历史报告查看功能

### DIFF
--- a/lib/ai-feedback.js
+++ b/lib/ai-feedback.js
@@ -13,6 +13,7 @@ const PROVIDER_ENDPOINTS = {
 
 /**
  * 发送请求到 OpenAI 兼容接口
+ * 支持标准 JSON 响应和 SSE 流式响应两种格式
  */
 async function callAPI(endpoint, apiKey, model, messages, maxTokens = 200) {
   const response = await fetch(endpoint, {
@@ -25,7 +26,8 @@ async function callAPI(endpoint, apiKey, model, messages, maxTokens = 200) {
       model,
       messages,
       max_tokens: maxTokens,
-      temperature: 0.7
+      temperature: 0.7,
+      stream: false
     })
   });
 
@@ -34,8 +36,41 @@ async function callAPI(endpoint, apiKey, model, messages, maxTokens = 200) {
     throw new Error(`API 请求失败 (${response.status}): ${error}`);
   }
 
-  const data = await response.json();
-  return data.choices[0].message.content;
+  // 获取响应文本
+  const rawText = await response.text();
+
+  // 检测是否为 SSE 流式响应（以 "data: " 开头）
+  if (rawText.startsWith('data: ')) {
+    // 解析 SSE 格式：取最后一条有完整 content 的 data
+    const lines = rawText.split('\n').filter(l => l.startsWith('data: '));
+    let fullContent = '';
+    for (const line of lines) {
+      const jsonStr = line.slice(6); // 去掉 "data: " 前缀
+      if (jsonStr === '[DONE]') continue;
+      try {
+        const chunk = JSON.parse(jsonStr);
+        const delta = chunk.choices?.[0]?.delta?.content || chunk.choices?.[0]?.text || '';
+        fullContent += delta;
+      } catch {
+        // 跳过无法解析的行
+      }
+    }
+    if (fullContent) return fullContent;
+    // 如果流式解析没拿到内容，fallback 到完整 JSON 解析
+  }
+
+  // 尝试标准 JSON 解析
+  try {
+    const data = JSON.parse(rawText);
+    // 兼容多种返回格式
+    return data.choices?.[0]?.message?.content
+      || data.choices?.[0]?.text
+      || data.response
+      || data.content
+      || '';
+  } catch (e) {
+    throw new Error(`API 返回格式异常: ${rawText.slice(0, 200)}`);
+  }
 }
 
 /**
@@ -155,7 +190,8 @@ async function testConnection(settings) {
         model: config.model,
         messages,
         max_tokens: 2,
-        temperature: 0
+        temperature: 0,
+        stream: false
       })
     });
 
@@ -164,6 +200,21 @@ async function testConnection(settings) {
       return { success: false, error: `API 请求失败 (${response.status}): ${error}` };
     }
 
+    // 尝试读取响应体，确保服务端返回了有效内容
+    const rawText = await response.text().catch(() => '');
+    if (!rawText) {
+      return { success: false, error: '服务端返回了空响应' };
+    }
+    // 兼容 SSE 格式的测试响应
+    if (rawText.startsWith('data: ')) {
+      // 能收到 SSE 数据说明连通性正常
+      return { success: true };
+    }
+    try {
+      JSON.parse(rawText);
+    } catch {
+      // 非 JSON 但收到了响应，也算连通
+    }
     return { success: true };
   } catch (error) {
     return { success: false, error: `连接失败: ${error.message}` };

--- a/main.js
+++ b/main.js
@@ -13,6 +13,53 @@ let settingsWindow;
 let promptEditorWindow;
 let asrReady = false;
 
+// ===== 报告持久化 =====
+function getReportsDir() {
+  return path.join(app.getPath('userData'), 'reports');
+}
+
+function getReportFilePath(id) {
+  return path.join(getReportsDir(), `${id}.json`);
+}
+
+function loadReports() {
+  const dir = getReportsDir();
+  if (!fs.existsSync(dir)) return [];
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'));
+  const reports = files.map(f => {
+    try {
+      const data = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8'));
+      return data;
+    } catch { return null; }
+  }).filter(Boolean);
+  // 按时间倒序排列
+  reports.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+  return reports;
+}
+
+function saveReport(report) {
+  const dir = getReportsDir();
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const filePath = getReportFilePath(report.id);
+  fs.writeFileSync(filePath, JSON.stringify(report, null, 2), 'utf-8');
+}
+
+function deleteReportFile(id) {
+  const filePath = getReportFilePath(id);
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+    return true;
+  }
+  return false;
+}
+
+function generateReportId() {
+  const now = new Date();
+  const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
+  const timeStr = now.toTimeString().slice(0, 8).replace(/:/g, '');
+  return `report-${dateStr}-${timeStr}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
 // Custom prompt 文件路径
 function getCustomPromptPath() {
   return path.join(app.getPath('userData'), 'custom-prompt.json');
@@ -332,4 +379,76 @@ ipcMain.handle('get-final-report', async (event, { fullText, stats }) => {
   } catch (error) {
     return { success: false, error: error.message };
   }
+});
+
+// ===== 异步报告生成 =====
+ipcMain.handle('request-report-async', async (event, { fullText, stats }) => {
+  const settings = loadSettings();
+  const providerConfig = getCurrentProviderSettings(settings);
+  const customPrompt = loadCustomPrompt();
+
+  // 立即返回一个 reportId，后台继续生成
+  const reportId = generateReportId();
+  const reportMeta = {
+    id: reportId,
+    createdAt: Date.now(),
+    date: new Date().toLocaleString('zh-CN'),
+    stats: { ...stats },
+    textPreview: fullText.slice(0, 100) + (fullText.length > 100 ? '...' : ''),
+    status: 'generating'
+  };
+  // 先保存元数据
+  saveReport(reportMeta);
+
+  // 异步生成，完成后推送
+  (async () => {
+    try {
+      const reportContent = await sendReport(fullText, stats, { ...settings, ...providerConfig }, customPrompt);
+      // 更新报告记录
+      const report = {
+        ...reportMeta,
+        status: 'completed',
+        report: reportContent,
+        fullText
+      };
+      saveReport(report);
+      // 推送给渲染进程
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('report-generated', { id: reportId, status: 'completed', report: reportContent });
+      }
+    } catch (error) {
+      // 更新为失败状态
+      const failedReport = {
+        ...reportMeta,
+        status: 'failed',
+        error: error.message
+      };
+      saveReport(failedReport);
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('report-generated', { id: reportId, status: 'failed', error: error.message });
+      }
+    }
+  })();
+
+  return { success: true, reportId };
+});
+
+// 获取报告历史列表
+ipcMain.handle('get-report-history', async () => {
+  return loadReports();
+});
+
+// 获取单条报告详情
+ipcMain.handle('get-report-detail', async (event, reportId) => {
+  const filePath = getReportFilePath(reportId);
+  if (fs.existsSync(filePath)) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  }
+  return null;
+});
+
+// 删除报告
+ipcMain.handle('delete-report', async (event, reportId) => {
+  const deleted = deleteReportFile(reportId);
+  return { success: deleted };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "node-microphone": "^0.1.0",
-        "sherpa-onnx-node": "^1.10.0"
+        "sherpa-onnx-node": "^1.13.4"
       },
       "devDependencies": {
         "electron": "^33.0.0"
@@ -18,7 +17,7 @@
     },
     "node_modules/@electron/get": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/@electron/get/-/get-2.0.3.tgz",
       "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
       "dev": true,
       "license": "MIT",
@@ -40,7 +39,7 @@
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true,
       "license": "MIT",
@@ -53,7 +52,7 @@
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "dev": true,
       "license": "MIT",
@@ -66,7 +65,7 @@
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "dev": true,
       "license": "MIT",
@@ -79,14 +78,14 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "dev": true,
       "license": "MIT",
@@ -96,7 +95,7 @@
     },
     "node_modules/@types/node": {
       "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/@types/node/-/node-20.19.43.tgz",
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
@@ -106,7 +105,7 @@
     },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
       "license": "MIT",
@@ -116,7 +115,7 @@
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
       "license": "MIT",
@@ -127,16 +126,15 @@
     },
     "node_modules/boolean": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
       "license": "MIT",
@@ -146,7 +144,7 @@
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "dev": true,
       "license": "MIT",
@@ -156,7 +154,7 @@
     },
     "node_modules/cacheable-request": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dev": true,
       "license": "MIT",
@@ -175,7 +173,7 @@
     },
     "node_modules/clone-response": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "dev": true,
       "license": "MIT",
@@ -188,7 +186,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -206,7 +204,7 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
       "license": "MIT",
@@ -222,7 +220,7 @@
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
       "license": "MIT",
@@ -235,7 +233,7 @@
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true,
       "license": "MIT",
@@ -245,7 +243,7 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
@@ -264,7 +262,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
       "license": "MIT",
@@ -283,16 +281,16 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/electron": {
-      "version": "33.4.11",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
-      "integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+      "version": "33.0.0",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/electron/-/electron-33.0.0.tgz",
+      "integrity": "sha512-OdLLR/zAVuNfKahSSYokZmSi7uK2wEYTbCoiIdqWLsOWmCqO9j0JC2XkYQmXQcAk2BJY0ri4lxwAfc5pzPDYsA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -310,7 +308,7 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
       "license": "MIT",
@@ -320,7 +318,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "license": "MIT",
@@ -330,7 +328,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
@@ -341,7 +339,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
@@ -352,7 +350,7 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
       "license": "MIT",
@@ -360,7 +358,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/escape-string-regexp/4.0.0/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -374,7 +372,7 @@
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -395,7 +393,7 @@
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "license": "MIT",
@@ -405,7 +403,7 @@
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/fs-extra/8.1.0/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "license": "MIT",
@@ -420,7 +418,7 @@
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/get-stream/5.2.0/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
       "license": "MIT",
@@ -436,7 +434,7 @@
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -455,7 +453,7 @@
     },
     "node_modules/global-agent/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
@@ -469,7 +467,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "license": "MIT",
@@ -487,7 +485,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
@@ -501,7 +499,7 @@
     },
     "node_modules/got": {
       "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "dev": true,
       "license": "MIT",
@@ -527,14 +525,14 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
@@ -548,14 +546,14 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "dev": true,
       "license": "MIT",
@@ -569,14 +567,14 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "license": "ISC",
@@ -584,7 +582,7 @@
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/jsonfile/4.0.0/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
@@ -594,7 +592,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -604,7 +602,7 @@
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/lowercase-keys/2.0.0/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true,
       "license": "MIT",
@@ -614,7 +612,7 @@
     },
     "node_modules/matcher": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/matcher/3.0.0/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
       "license": "MIT",
@@ -628,7 +626,7 @@
     },
     "node_modules/mimic-response": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/mimic-response/1.0.1/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true,
       "license": "MIT",
@@ -638,23 +636,14 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-microphone": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/node-microphone/-/node-microphone-0.1.6.tgz",
-      "integrity": "sha512-5229wtpVYNU2gR8zpkABVSdp4wT9qagJgj6pELEIkAVbOXFmaCM35qN3z4ylu3OwFfEKqQ4h9u8Lb58DzaBieQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/normalize-url": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true,
       "license": "MIT",
@@ -667,7 +656,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
       "license": "MIT",
@@ -678,7 +667,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
@@ -688,7 +677,7 @@
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "dev": true,
       "license": "MIT",
@@ -698,14 +687,14 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
       "license": "MIT",
@@ -715,7 +704,7 @@
     },
     "node_modules/pump": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
@@ -726,7 +715,7 @@
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
       "license": "MIT",
@@ -739,14 +728,14 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/responselike": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "dev": true,
       "license": "MIT",
@@ -759,7 +748,7 @@
     },
     "node_modules/roarr": {
       "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -778,7 +767,7 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -788,7 +777,7 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true,
       "license": "MIT",
@@ -796,7 +785,7 @@
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/serialize-error/7.0.1/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "dev": true,
       "license": "MIT",
@@ -812,9 +801,9 @@
       }
     },
     "node_modules/sherpa-onnx-darwin-arm64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.13.3.tgz",
-      "integrity": "sha512-9x86Cbf+BDFONdtCPM3cnjvtAW0ER8tMaHK5pVfz+SHPt8GeuwRXaiR/BzcByFBUyxCgmceO09/WMZOCi44P/g==",
+      "version": "1.13.4",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.13.4.tgz",
+      "integrity": "sha512-QcYKzyrTzGSx6aKCD6hUODgRS1LetqfG57Z/+i5LCyfMlrgCvDc1lRcl9cdB+TozBsLha9QwLTlI0vmDcf5JKg==",
       "cpu": [
         "arm64"
       ],
@@ -825,9 +814,9 @@
       ]
     },
     "node_modules/sherpa-onnx-darwin-x64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.13.3.tgz",
-      "integrity": "sha512-TVQ35g7JIpDPB1lUDdcog+JtI0cI45ZzOnvHXm0DtWs/dgxnJXtWMY3uLRtBbLnysV9j5ljffwZ1IX9VDHsCzQ==",
+      "version": "1.13.4",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.13.4.tgz",
+      "integrity": "sha512-6RGeis9K9gV/UQWOgd6Rf3iqXr2/YsBQswxHaCR4hrYkHfEIpHMfFmRWLt6nJJCOWgYW2xFxEd9yzjrafAV/Pw==",
       "cpu": [
         "x64"
       ],
@@ -838,9 +827,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-arm64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.13.3.tgz",
-      "integrity": "sha512-uDtZkkoP6QQ/3DHOscCpEZ2WpaiHUQsDpbyYaHURrJ7DbsjqGnS6G8l+R589Ro5Bf282QElzBy3okwxXbt3Kxw==",
+      "version": "1.13.4",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.13.4.tgz",
+      "integrity": "sha512-RMjMRqT82BgTXypNNGmLe6ZFYhc3WEvnAGl3DdkK7qB/kuXwkL3iHhV31wAecbnWPsnEpUoD+8cFovWSBzsCuw==",
       "cpu": [
         "arm64"
       ],
@@ -851,9 +840,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-x64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.13.3.tgz",
-      "integrity": "sha512-OFVK0GYwKwKNsjxbPmfcLQm/dfA0IwAoiIQJ96s+eFYcDqhlapcY06ocdb7SNluGBcM7xgU5jEW2QXBkMIOEvQ==",
+      "version": "1.13.4",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.13.4.tgz",
+      "integrity": "sha512-WZh5NCkGPFHHpYSd78iN4OnmxQeSTGyt9uZskH+im/NFHQ7elQ7B0sLzCMeRpvJxiIKvd9C6WxIJ4hYaxClfsQ==",
       "cpu": [
         "x64"
       ],
@@ -864,23 +853,23 @@
       ]
     },
     "node_modules/sherpa-onnx-node": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-node/-/sherpa-onnx-node-1.13.3.tgz",
-      "integrity": "sha512-3XEiRvfZ73QoKDZqweAkAOb+OA2LPMKcLcRY6zngjhwZ1ymV6xagdahepYzeDRIzVq0nRjhUe8IaRdlRMYoamw==",
+      "version": "1.13.4",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/sherpa-onnx-node/-/sherpa-onnx-node-1.13.4.tgz",
+      "integrity": "sha512-jHWWdY9f0dbvJpdsfR/C4WNhM57+jT9Os2RyC4/qUz8HKCtj2VYFmJ9s7tue9OCFRAmdoGBkgkqD6aBZ3I8BKw==",
       "license": "Apache-2.0",
       "optionalDependencies": {
-        "sherpa-onnx-darwin-arm64": "^1.13.3",
-        "sherpa-onnx-darwin-x64": "^1.13.3",
-        "sherpa-onnx-linux-arm64": "^1.13.3",
-        "sherpa-onnx-linux-x64": "^1.13.3",
-        "sherpa-onnx-win-ia32": "^1.13.3",
-        "sherpa-onnx-win-x64": "^1.13.3"
+        "sherpa-onnx-darwin-arm64": "^1.13.4",
+        "sherpa-onnx-darwin-x64": "^1.13.4",
+        "sherpa-onnx-linux-arm64": "^1.13.4",
+        "sherpa-onnx-linux-x64": "^1.13.4",
+        "sherpa-onnx-win-ia32": "^1.13.4",
+        "sherpa-onnx-win-x64": "^1.13.4"
       }
     },
     "node_modules/sherpa-onnx-win-ia32": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.13.3.tgz",
-      "integrity": "sha512-VDZh1M7Ccx/bkP3WwBCFoJzwAwq+b5nR1KRkYRz5p1w5bfhzfa3ACBGr7vpUt5AGUge4qSLe0MSKXyKtSmy1uA==",
+      "version": "1.13.4",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.13.4.tgz",
+      "integrity": "sha512-/JbPjldrfNv+t+uIS3MlkuhfIf5l3FHUGkRC2oRXgjRqOaVmEyP3vLlQ7dTa4J7raG5oB8c3GoPjuSWSqT9GOQ==",
       "cpu": [
         "ia32"
       ],
@@ -891,9 +880,9 @@
       ]
     },
     "node_modules/sherpa-onnx-win-x64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.13.3.tgz",
-      "integrity": "sha512-ZQzcSmFvZK4jzmtWckqxocDUuEjYnBV2MHrDD21HPTeUMfGdE9yfvuSPpesIVfdzKbQzIQY42RAcfZEGWu0FbQ==",
+      "version": "1.13.4",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.13.4.tgz",
+      "integrity": "sha512-R0PWby1VxC14TDZPq7GcfSyXSY6SAFO8Y4JwdCdqouFmeXkZ1L7Is9m98C9KxQ0dN7ZtDzhAmE/43FUs/elXRQ==",
       "cpu": [
         "x64"
       ],
@@ -905,7 +894,7 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -913,7 +902,7 @@
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -926,7 +915,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/type-fest/0.13.1/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
@@ -940,14 +929,14 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/universalify/0.1.2/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
@@ -957,14 +946,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "resolved": "https://cmc.centralrepo.rnd.huawei.com/artifactory/api/npm/npm-public/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,19 @@
     "start": "electron .",
     "dev": "electron . --dev"
   },
-  "keywords": ["expression", "training", "speech", "asr", "chinese"],
+  "keywords": [
+    "expression",
+    "training",
+    "speech",
+    "asr",
+    "chinese"
+  ],
   "author": "sisi",
   "license": "MIT",
   "devDependencies": {
     "electron": "^33.0.0"
   },
   "dependencies": {
-    "sherpa-onnx-node": "^1.10.0"
+    "sherpa-onnx-node": "^1.13.4"
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -33,4 +33,18 @@ contextBridge.exposeInMainWorld('api', {
 
   // 文件保存
   saveFile: (content, filename) => ipcRenderer.invoke('save-file', content, filename),
+
+  // 异步报告生成
+  requestReportAsync: (data) => ipcRenderer.invoke('request-report-async', data),
+  onReportGenerated: (callback) => {
+    ipcRenderer.on('report-generated', (event, data) => callback(data));
+  },
+  removeReportListener: () => {
+    ipcRenderer.removeAllListeners('report-generated');
+  },
+
+  // 历史报告
+  getReportHistory: () => ipcRenderer.invoke('get-report-history'),
+  getReportDetail: (id) => ipcRenderer.invoke('get-report-detail', id),
+  deleteReport: (id) => ipcRenderer.invoke('delete-report', id),
 });

--- a/src/app.js
+++ b/src/app.js
@@ -13,9 +13,11 @@ class ExpressionTrainer {
     this.stats = { fillers: 0, hedges: 0, vagueWords: 0, totalWords: 0, duration: 0 };
     this.lastFeedbackText = '';
     this.lastReport = '';
+    this.currentReportId = null; // 异步报告ID
 
     this.initElements();
     this.bindEvents();
+    this.setupReportListener();
   }
 
   initElements() {
@@ -45,6 +47,13 @@ class ExpressionTrainer {
     this.statHedges = document.getElementById('stat-hedges');
     this.statVague = document.getElementById('stat-vague');
     this.statDensity = document.getElementById('stat-density');
+    // 历史报告
+    this.btnHistory = document.getElementById('btn-history');
+    this.historyModal = document.getElementById('history-modal');
+    this.historyBody = document.getElementById('history-body');
+    this.historyList = document.getElementById('history-list');
+    this.historyDetail = document.getElementById('history-detail');
+    this.btnCloseHistory = document.getElementById('btn-close-history');
   }
 
   bindEvents() {
@@ -69,6 +78,9 @@ class ExpressionTrainer {
     this.btnCopyText.addEventListener('click', () => this.copyOriginalText());
     this.btnSaveText.addEventListener('click', () => this.saveOriginalText());
     this.btnClear.addEventListener('click', () => this.clearAll());
+    // 历史报告
+    this.btnHistory.addEventListener('click', () => this.showReportHistory());
+    this.btnCloseHistory.addEventListener('click', () => this.historyModal.classList.add('hidden'));
   }
 
   // ===== 录制控制 =====
@@ -306,64 +318,43 @@ class ExpressionTrainer {
 
   // ===== 报告 =====
 
+  setupReportListener() {
+    window.api.onReportGenerated((data) => {
+      if (data.status === 'completed') {
+        this.lastReport = data.report;
+        // 如果报告弹窗当前是打开状态且显示的是该报告的"生成中"状态，则自动填充
+        if (!this.reportModal.classList.contains('hidden') && this.currentReportId === data.id) {
+          this.renderReport(data.report);
+        }
+        this.addFeedbackItem('✅ 报告生成完成', 'good');
+      } else if (data.status === 'failed') {
+        if (!this.reportModal.classList.contains('hidden') && this.currentReportId === data.id) {
+          this.reportBody.innerHTML = `<p style="color:#ff6b6b;">生成失败: ${data.error}</p>`;
+        }
+        this.addFeedbackItem(`❌ 报告生成失败: ${data.error}`, 'hedge');
+      }
+    });
+  }
+
   async generateReport() {
-    this.reportBody.innerHTML = '<p style="text-align:center;color:#666;padding:40px;">正在生成报告...</p>';
+    // 异步启动报告生成
+    this.reportBody.innerHTML = `
+      <div style="text-align:center;padding:40px;">
+        <div style="font-size:24px;margin-bottom:12px;">⏳</div>
+        <p style="color:#ffa94d;">正在后台生成报告...</p>
+        <p style="color:#666;font-size:12px;margin-top:8px;">生成完成后会自动通知你，可先关闭此窗口继续训练</p>
+      </div>`;
     this.reportModal.classList.remove('hidden');
 
-    const result = await window.api.getFinalReport({
+    const result = await window.api.requestReportAsync({
       fullText: this.fullText,
       stats: this.stats
     });
 
     if (result.success) {
-      this.lastReport = result.report;
-      this.renderReport(result.report);
+      this.currentReportId = result.reportId;
     } else {
-      this.reportBody.innerHTML = `<p style="color:#ff6b6b;">生成失败: ${result.error}</p>`;
-    }
-  }
-
-  renderReport(report) {
-    let html = report
-      .replace(/^### (.+)$/gm, '<h3>$1</h3>')
-      .replace(/^## (.+)$/gm, '<h2>$1</h2>')
-      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-      .replace(/`([^`]+)`/g, '<code>$1</code>')
-      .replace(/^> (.+)$/gm, '<blockquote>$1</blockquote>')
-      .replace(/\|(.+)\|/g, (match) => {
-        // 简单表格支持
-        return match;
-      })
-      .replace(/\n/g, '<br>');
-
-    this.reportBody.innerHTML = `
-      <div style="text-align:right;margin-bottom:12px;">
-        <button id="btn-save-report" style="background:#E5007E;color:#fff;border:none;border-radius:6px;padding:8px 14px;font-size:12px;cursor:pointer;">💾 保存为 Markdown</button>
-      </div>
-      ${html}
-    `;
-
-    document.getElementById('btn-save-report').addEventListener('click', () => this.saveReport());
-  }
-
-  async saveReport() {
-    if (!this.lastReport) return;
-    const now = new Date();
-    const dateStr = now.toISOString().slice(0, 10);
-    const timeStr = now.toTimeString().slice(0, 5).replace(':', '');
-    const markdown = `# 表达训练报告\n\n**日期**: ${dateStr}  \n**时长**: ${this.stats.duration}秒  \n**总字数**: ${this.stats.totalWords}  \n\n---\n\n## 完整原文\n\n${this.fullText}\n\n---\n\n${this.lastReport}`;
-    const filename = `表达训练-${dateStr}-${timeStr}.md`;
-
-    try {
-      const result = await window.api.saveFile(markdown, filename);
-      if (result.success) {
-        const btn = document.getElementById('btn-save-report');
-        btn.textContent = '✓ 已保存';
-        btn.style.background = '#333';
-        setTimeout(() => { btn.textContent = '💾 保存为 Markdown'; btn.style.background = '#E5007E'; }, 2000);
-      }
-    } catch (e) {
-      alert('保存失败: ' + e.message);
+      this.reportBody.innerHTML = `<p style="color:#ff6b6b;">启动生成失败: ${result.error}</p>`;
     }
   }
 
@@ -487,6 +478,194 @@ class ExpressionTrainer {
 
     // 请求AI语境化反馈
     this.requestRealtimeFeedback();
+  }
+
+  // ===== 历史报告 =====
+
+  async showReportHistory() {
+    this.historyDetail.classList.add('hidden');
+    this.historyList.classList.remove('hidden');
+    this.historyModal.classList.remove('hidden');
+
+    const reports = await window.api.getReportHistory();
+    this.renderHistoryList(reports);
+  }
+
+  renderHistoryList(reports) {
+    if (!reports || reports.length === 0) {
+      this.historyList.innerHTML = '<div class="history-empty">暂无历史报告\n完成一次训练并生成报告后，这里会显示记录</div>';
+      return;
+    }
+
+    this.historyList.innerHTML = reports.map(r => {
+      const statusLabel = r.status === 'completed' ? '✅ 已完成' :
+                          r.status === 'generating' ? '⏳ 生成中' :
+                          '❌ 失败';
+      const statusClass = r.status === 'completed' ? 'completed' :
+                          r.status === 'generating' ? 'generating' : 'failed';
+
+      const statsHtml = r.stats ? `
+        <div class="history-item-stats">
+          <span>🔴 ${r.stats.fillers || 0}</span>
+          <span>🟡 ${r.stats.hedges || 0}</span>
+          <span>🟠 ${r.stats.vagueWords || 0}</span>
+          <span>🟢 ${r.stats.totalWords || 0}字</span>
+          ${r.stats.duration ? `<span>⏱️ ${Math.floor(r.stats.duration / 60)}分${r.stats.duration % 60}秒</span>` : ''}
+        </div>` : '';
+
+      const deleteBtn = r.status !== 'generating'
+        ? `<button class="history-btn-delete" data-id="${r.id}" title="删除">🗑️</button>`
+        : '';
+
+      return `
+        <div class="history-item" data-id="${r.id}">
+          <div class="history-item-left">
+            <div class="history-item-date">${r.date || '未知时间'}</div>
+            <div class="history-item-preview">${r.textPreview || '(无文本)'}</div>
+            ${statsHtml}
+          </div>
+          <div class="history-item-right">
+            <span class="history-status ${statusClass}">${statusLabel}</span>
+            ${r.status === 'completed' ? `<button class="history-btn-view" data-id="${r.id}">查看</button>` : ''}
+            ${deleteBtn}
+          </div>
+        </div>`;
+    }).join('');
+
+    // 绑定事件
+    this.historyList.querySelectorAll('.history-btn-view').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.viewReportDetail(btn.dataset.id);
+      });
+    });
+    this.historyList.querySelectorAll('.history-btn-delete').forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        await this.deleteReportItem(btn.dataset.id);
+      });
+    });
+    this.historyList.querySelectorAll('.history-item').forEach(item => {
+      item.addEventListener('click', () => {
+        const id = item.dataset.id;
+        const report = reports.find(r => r.id === id);
+        if (report && report.status === 'completed') {
+          this.viewReportDetail(id);
+        }
+      });
+    });
+  }
+
+  async viewReportDetail(reportId) {
+    const report = await window.api.getReportDetail(reportId);
+    if (!report || report.status !== 'completed') return;
+
+    this.historyList.classList.add('hidden');
+    this.historyDetail.classList.remove('hidden');
+
+    const statsHtml = report.stats ? `
+      <div class="history-detail-stats">
+        <span>🔴 填充词: ${report.stats.fillers || 0}</span>
+        <span>🟡 犹豫词: ${report.stats.hedges || 0}</span>
+        <span>🟠 笼统词: ${report.stats.vagueWords || 0}</span>
+        <span>🟢 总字数: ${report.stats.totalWords || 0}</span>
+        ${report.stats.duration ? `<span>⏱️ 时长: ${Math.floor(report.stats.duration / 60)}分${report.stats.duration % 60}秒</span>` : ''}
+        ${report.stats.totalWords ? `<span>📊 密度: ${((report.stats.totalWords - (report.stats.fillers || 0) - (report.stats.hedges || 0)) / report.stats.totalWords * 100).toFixed(0)}%</span>` : ''}
+      </div>` : '';
+
+    this.historyDetail.innerHTML = `
+      <div class="history-detail-header">
+        <button class="history-btn-back" id="history-btn-back">← 返回列表</button>
+        <span class="history-detail-date">${report.date || '未知时间'}</span>
+      </div>
+      ${statsHtml}
+      <div class="history-detail-report">${this.renderReportContent(report.report || '')}</div>`;
+
+    document.getElementById('history-btn-back').addEventListener('click', () => {
+      this.showReportHistory();
+    });
+  }
+
+  async deleteReportItem(reportId) {
+    const result = await window.api.deleteReport(reportId);
+    if (result.success) {
+      this.addFeedbackItem('🗑️ 已删除一条历史报告', 'good');
+      // 刷新列表
+      const reports = await window.api.getReportHistory();
+      this.renderHistoryList(reports);
+    }
+  }
+
+  renderReportContent(reportText) {
+    // 将 Markdown 格式的报告转换为 HTML
+    let html = reportText
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      // 代码块
+      .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
+      // 行内代码
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      // 标题
+      .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+      .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+      .replace(/^# (.+)$/gm, '<h2>$1</h2>')
+      // 加粗
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      // 引用
+      .replace(/^> (.+)$/gm, '<blockquote>$1</blockquote>')
+      // 无序列表
+      .replace(/^- (.+)$/gm, '<li>$1</li>')
+      .replace(/(<li>.*<\/li>\n?)+/g, '<ul>$&</ul>')
+      // 段落
+      .replace(/\n\n/g, '</p><p>')
+      .replace(/\n/g, '<br>');
+
+    // 表格处理：将连续的 |...| 行包裹在 <table> 中
+    html = html.replace(/((?:<br>)?\|[^|]+\|<br>(?:\|[^|]+\|<br>)*)/g, (match) => {
+      const rows = match.split('<br>').filter(r => r.trim());
+      const isSep = rows.some(r => /^\|[\s:|-]+\|$/.test(r));
+      const tableRows = rows.map(r => {
+        const cells = r.replace(/^\||\|$/g, '').split('|').map(c => c.trim());
+        if (cells.every(c => /^:?-+:?$/.test(c))) return '';
+        return `<tr>${cells.map(c => `<td>${c}</td>`).join('')}</tr>`;
+      }).filter(Boolean).join('');
+      return tableRows ? `<table>${tableRows}</table>` : match;
+    });
+
+    return `<p>${html}</p>`;
+  }
+
+  // 重写 renderReport 使用 renderReportContent
+  renderReport(reportText) {
+    this.reportBody.innerHTML = `
+      <div style="text-align:right;margin-bottom:12px;">
+        <button id="btn-save-report" style="background:#E5007E;color:#fff;border:none;border-radius:6px;padding:8px 14px;font-size:12px;cursor:pointer;">💾 保存为 Markdown</button>
+      </div>
+      ${this.renderReportContent(reportText)}`;
+
+    document.getElementById('btn-save-report').addEventListener('click', () => this.saveReportToFile());
+  }
+
+  async saveReportToFile() {
+    if (!this.lastReport) return;
+    const now = new Date();
+    const dateStr = now.toISOString().slice(0, 10);
+    const timeStr = now.toTimeString().slice(0, 5).replace(':', '');
+    const markdown = `# 表达训练报告\n\n**日期**: ${dateStr}  \n**时长**: ${this.stats.duration}秒  \n**总字数**: ${this.stats.totalWords}  \n\n---\n\n## 完整原文\n\n${this.fullText}\n\n---\n\n${this.lastReport}`;
+    const filename = `表达训练-${dateStr}-${timeStr}.md`;
+
+    try {
+      const result = await window.api.saveFile(markdown, filename);
+      if (result.success) {
+        const btn = document.getElementById('btn-save-report');
+        btn.textContent = '✓ 已保存';
+        btn.style.background = '#333';
+        setTimeout(() => { btn.textContent = '💾 保存为 Markdown'; btn.style.background = '#E5007E'; }, 2000);
+      }
+    } catch (e) {
+      alert('保存失败: ' + e.message);
+    }
   }
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -95,6 +95,9 @@
       <div id="feedback-content" class="feedback-content">
         <!-- 实时反馈内容 -->
       </div>
+      <div class="panel-right-footer">
+        <button id="btn-history" class="btn-sm btn-history" title="查看历史报告">📜 历史报告</button>
+      </div>
     </aside>
   </div>
 
@@ -138,6 +141,22 @@
         </div>
       </div>
       <div id="report-body" class="modal-body">
+      </div>
+    </div>
+  </div>
+
+  <!-- 历史报告弹窗 -->
+  <div id="history-modal" class="modal hidden">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2>📜 历史报告</h2>
+        <div class="modal-header-actions">
+          <button id="btn-close-history" class="btn-close">×</button>
+        </div>
+      </div>
+      <div id="history-body" class="modal-body">
+        <div id="history-list" class="history-list"></div>
+        <div id="history-detail" class="history-detail hidden"></div>
       </div>
     </div>
   </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -295,3 +295,218 @@ button, input, select, .subtitle-scroll, .feedback-content, .modal-body {
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: #333; border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: #555; }
+
+/* ===== 历史报告 ===== */
+.panel-right-footer {
+  padding: 8px 0 0;
+  border-top: 1px solid #1a1a1a;
+  flex-shrink: 0;
+}
+
+.btn-history {
+  width: 100%;
+  padding: 6px 12px;
+  font-size: 12px;
+  border: 1px solid #333;
+  border-radius: 6px;
+  background: #1a1a1a;
+  color: #aaa;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: center;
+}
+
+.btn-history:hover {
+  background: #2a2a2a;
+  color: #fff;
+  border-color: #E5007E;
+}
+
+/* 历史报告列表 */
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.history-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: #1a1a1a;
+  border: 1px solid #222;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.history-item:hover {
+  border-color: #E5007E;
+  background: #222;
+}
+
+.history-item-left {
+  flex: 1;
+  min-width: 0;
+}
+
+.history-item-date {
+  font-size: 12px;
+  color: #888;
+  margin-bottom: 4px;
+}
+
+.history-item-preview {
+  font-size: 13px;
+  color: #ccc;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.history-item-stats {
+  display: flex;
+  gap: 12px;
+  margin-top: 6px;
+  font-size: 11px;
+  color: #666;
+}
+
+.history-item-stats span {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.history-item-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  margin-left: 12px;
+}
+
+.history-status {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+
+.history-status.completed {
+  background: rgba(105, 219, 124, 0.15);
+  color: #69db7c;
+}
+
+.history-status.generating {
+  background: rgba(255, 169, 77, 0.15);
+  color: #ffa94d;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.history-status.failed {
+  background: rgba(255, 107, 107, 0.15);
+  color: #ff6b6b;
+}
+
+.history-btn-view {
+  padding: 4px 10px;
+  font-size: 11px;
+  border: 1px solid #444;
+  border-radius: 4px;
+  background: transparent;
+  color: #aaa;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.history-btn-view:hover {
+  border-color: #E5007E;
+  color: #fff;
+}
+
+.history-btn-delete {
+  padding: 4px 8px;
+  font-size: 11px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: #555;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.history-btn-delete:hover {
+  color: #ff6b6b;
+  background: rgba(255, 107, 107, 0.1);
+}
+
+.history-empty {
+  text-align: center;
+  color: #666;
+  padding: 60px 20px;
+  font-size: 14px;
+}
+
+/* 历史报告详情 */
+.history-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #222;
+}
+
+.history-btn-back {
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid #444;
+  border-radius: 4px;
+  background: transparent;
+  color: #aaa;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.history-btn-back:hover {
+  border-color: #E5007E;
+  color: #fff;
+}
+
+.history-detail-date {
+  font-size: 12px;
+  color: #888;
+}
+
+.history-detail-stats {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  background: #1a1a1a;
+  border-radius: 8px;
+  font-size: 12px;
+  color: #ccc;
+}
+
+.history-detail-stats span {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.history-detail-report {
+  font-size: 14px;
+  line-height: 1.9;
+  color: #ddd;
+}
+
+.history-detail-report h2 { color: #E5007E; margin-top: 20px; margin-bottom: 8px; font-size: 16px; }
+.history-detail-report h3 { color: #fff; margin-top: 14px; font-size: 14px; }
+.history-detail-report blockquote { border-left: 3px solid #E5007E; padding-left: 12px; color: #999; margin: 8px 0; }
+.history-detail-report code { background: #1a1a1a; padding: 2px 6px; border-radius: 4px; color: #E5007E; font-size: 13px; }
+.history-detail-report table { width: 100%; border-collapse: collapse; margin: 8px 0; }
+.history-detail-report th, .history-detail-report td { border: 1px solid #333; padding: 6px 10px; text-align: left; font-size: 13px; }
+.history-detail-report th { background: #1a1a1a; color: #E5007E; }


### PR DESCRIPTION
- main.js: 新增报告持久化模块(save/load/delete)，异步报告生成 IPC handler (request-report-async)，报告完成后通过 report-generated 事件推送
- preload.js: 桥接 6 个新 API(requestReportAsync/onReportGenerated/等)
- src/index.html: 新增历史报告弹窗(列表+详情视图)和按钮
- src/styles.css: 新增约 220 行历史报告样式
- src/app.js: generateReport 改为异步非阻塞，新增历史报告管理 和 Markdown 渲染方法
- lib/ai-feedback.js: 修复 SSE 流式数据兼容性